### PR TITLE
Update cloudbox.md

### DIFF
--- a/docs/community/guides/cloudbox.md
+++ b/docs/community/guides/cloudbox.md
@@ -65,11 +65,13 @@ Backup from Cloudbox as you normally would. You will need to make the backup dri
 
     ``` { .shell }
 
-      sb install preinstall`
+      sb install preinstall
 
     ```
-
-- switch to the newly created user specified in your configuration. <br />
+- Modify the `/srv/git/saltbox/backup_config.yml` to include the path to your Backup directory in the `rclone` entry.<br />
+The default settings for Cloudbox is as follows: <br />
+` destination: google:/Backups/Cloubox`
+- Switch to the newly created user specified in your configuration. <br />
 
     ``` { .shell }
 

--- a/docs/community/guides/cloudbox.md
+++ b/docs/community/guides/cloudbox.md
@@ -68,7 +68,7 @@ Backup from Cloudbox as you normally would. You will need to make the backup dri
       sb install preinstall
 
     ```
-- Either copy over the rest of your backed-up files from Cloudbox (such as your `accounts.yml`, `adv_settings.yml`, `ansible.cfg`, and `backup_config.yml`) into `/srv/git/saltbox` *or* modify the `/srv/git/saltbox/backup_config.yml` to include the path to your Backup directory in the `rclone` entry.<br />
+- Modify the `/srv/git/saltbox/backup_config.yml` to include the path to your Backup directory in the `rclone` entry.<br />
    - The default setting for Cloudbox is as follows: <br />
 ` destination: google:/Backups/Cloubox`
 - Switch to the newly created user specified in your configuration. <br />

--- a/docs/community/guides/cloudbox.md
+++ b/docs/community/guides/cloudbox.md
@@ -68,8 +68,8 @@ Backup from Cloudbox as you normally would. You will need to make the backup dri
       sb install preinstall
 
     ```
-- Modify the `/srv/git/saltbox/backup_config.yml` to include the path to your Backup directory in the `rclone` entry.<br />
-The default settings for Cloudbox is as follows: <br />
+- Either copy over the rest of your backed-up files from Cloudbox (such as your `accounts.yml`, `adv_settings.yml`, `ansible.cfg`, and `backup_config.yml`) into `/srv/git/saltbox` *or* modify the `/srv/git/saltbox/backup_config.yml` to include the path to your Backup directory in the `rclone` entry.<br />
+   - The default setting for Cloudbox is as follows: <br />
 ` destination: google:/Backups/Cloubox`
 - Switch to the newly created user specified in your configuration. <br />
 


### PR DESCRIPTION
Fixed a small typo where ` was appended to the end of a command as well as added step involving modifying the backup_config.yml to point to backups/cloudbox instead of backups/saltbox