### PR TITLE
Update unifi.md

### DIFF
--- a/docs/sandbox/apps/unifi.md
+++ b/docs/sandbox/apps/unifi.md
@@ -52,9 +52,6 @@ sb install sandbox-unifi
       ### Open Specified Ports for the specified container ###
       ##### Unifi Ports for aditional services #####
       unifi_docker_ports_custom:
-        - "3478:3478/udp" #Unifi STUN port
-        - "10001:10001/udp" #Required for AP discovery
-        - "8080:8080/tcp" #Required for device communication
         - "1900:1900/udp" #Required for Make controller discoverable on L2 network option
         - "8843:8843/tcp" #Unifi guest portal HTTPS redirect port
         - "8880:8880/tcp" #Unifi guest portal HTTP redirect port


### PR DESCRIPTION
Removed ports from Open Specified Ports that are already added on container creation.
IE: 3478,10001, & 8080 - Was causing the following error during container creation:

fatal: [localhost]: FAILED! => {"attempts": 1, "changed": false, "msg": "Error starting container 069151360ca31339adcd570fe2dd250ff027fc9fa0fe4c42323be546505f8257: 500 Server Error for http+docker://localhost/v1.41/containers/069151360ca31339adcd570fe2dd250ff027fc9fa0fe4c42323be546505f8257/start: Internal Server Error (\"driver failed programming external connectivity on endpoint unifi (9d09316eafb37b83241feafa9fa2c74b338b316c4a98f49fddeb730f9c39c51e): Bind for 0.0.0.0:8080 failed: port is already allocated\")"}

