### PR TITLE
Fix correct tag in installation instruction

### DIFF
--- a/docs/sandbox/apps/plex-utills.md
+++ b/docs/sandbox/apps/plex-utills.md
@@ -29,7 +29,7 @@ Much like the 4K poster script, this will go through your films and add a 3D ban
 
 ``` shell
 
-sb install sandbox-plex-utills
+sb install sandbox-plex_utills
 
 ```
 


### PR DESCRIPTION
Installation instruction uses `sandbox-plex-utills` instead of `sandbox-plex_utills`