### PR TITLE
Add-Tdarr node to Docs

### DIFF
--- a/docs/sandbox/apps/tdarr_node.md
+++ b/docs/sandbox/apps/tdarr_node.md
@@ -18,9 +18,20 @@ sb install sandbox-tdarr_node
 
 ```
 
-### 2. URL
+### 2. Usage
 
-- To access Tdarr, visit `https://tdarr._yourdomain.com_`
+The Tdarr Node is configured with the following defaults which can be modified via the inventory system.
+
+``` yaml
+tdarr_node_server_ip: "tdarr"
+tdarr_node_server_port: "8266"
+tdarr_node_node_id: "MainNode"
+tdarr_node_node_ip: "0.0.0.0"
+tdarr_node_node_port: "8267"
+tdarr_node_external: false
+```
+
+By switching `tdarr_node_external` to `true` the node will be accessible externally via the specified `tdarr_node_node_port` on any hostname or IP address pointing to the server.
 
 ### 3. Setup
 

--- a/docs/sandbox/apps/tdarr_node.md
+++ b/docs/sandbox/apps/tdarr_node.md
@@ -2,7 +2,9 @@
 
 ## What is it?
 
-[Tdarr Node](https://tdarr.io/){: target=_blank rel="noopener noreferrer" } is a cross-platform conditional based transcoding application for automating media library transcode/remux management in order to process your media files as required. For example, you can set rules for the required codecs, containers, languages etc that your media should have which helps keeps things organized and can increase compatability with your devices. A common use for Tdarr is to simply convert video files from h264 to h265 (hevc), saving 40%-50% in size.
+[Tdarr Node](https://tdarr.io/){: target=_blank rel="noopener noreferrer" } is a cross-platform conditional based transcoding application for automating media library transcode/remux management in order to process your media files as required.
+
+- Node is described as: Processes running same/other devices which collect tasks from the Server.
 
 | Details     |             |             |             |
 |-------------|-------------|-------------|-------------|

--- a/docs/sandbox/apps/tdarr_node.md
+++ b/docs/sandbox/apps/tdarr_node.md
@@ -1,0 +1,25 @@
+# Tdarr Node
+
+## What is it?
+
+[Tdarr Node](https://tdarr.io/){: target=_blank rel="noopener noreferrer" } is a cross-platform conditional based transcoding application for automating media library transcode/remux management in order to process your media files as required. For example, you can set rules for the required codecs, containers, languages etc that your media should have which helps keeps things organized and can increase compatability with your devices. A common use for Tdarr is to simply convert video files from h264 to h265 (hevc), saving 40%-50% in size.
+
+| Details     |             |             |             |
+|-------------|-------------|-------------|-------------|
+| [:material-home: Project home ](https://tdarr.io/){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-link-16: Docs](https://docs.tdarr.io/docs/installation/getting-started){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-mark-github-16: Github](https://github.com/HaveAGitGat/Tdarr){: .header-icons target=_blank rel="noopener noreferrer" } | [:material-docker: Docker ](https://hub.docker.com/r/haveagitgat/tdarr){: .header-icons target=_blank rel="noopener noreferrer" }|
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-tdarr_node
+
+```
+
+### 2. URL
+
+- To access Tdarr, visit `https://tdarr._yourdomain.com_`
+
+### 3. Setup
+
+- [:octicons-link-16: Documentation: Tdarr Node Docs](https://docs.tdarr.io/docs/installation/getting-started){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -76,6 +76,7 @@
   -  **[stash](../sandbox/apps/stash.md)**  - tag - `sandbox-stash`
   -  **[tandoor](../sandbox/apps/tandoor.md)**  - tag - `sandbox-tandoor`
   -  **[tdarr](../sandbox/apps/tdarr.md)**  - tag - `sandbox-tdarr`
+  -  **[tdarr_node](../sandbox/apps/tdarr_node.md)**  - tag - `sandbox-tdarr_node`
   -  **[thelounge](../sandbox/apps/thelounge.md)**  - tag - `sandbox-thelounge`
   -  **[traefik_robotstxt](../sandbox/apps/traefik_robotstxt.md)**  - tag - `sandbox-traefik_robotstxt`
   -  **[unifi](../sandbox/apps/unifi.md)**  - tag - `sandbox-unifi`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
           - sqlitebrowser: sandbox/apps/sqlitebrowser.md
           - sshwifty: sandbox/apps/sshwifty.md
           - Tdarr: sandbox/apps/tdarr.md
+          - Tdarr Node: sandbox/apps/tdarr_node.md
           - System:
             - apprise: sandbox/apps/apprise.md
             - glances_web: sandbox/apps/glances_web.md


### PR DESCRIPTION
Added tdarr node reference to index.md, mkdocs.yml, and created the docs page. 

- [x] App documentation page created
- [x] Reference added in `sandbox/index.md`
- [x] Reference added in `mkdocs.yml`

To confirm you have read the above, please remove line.
