### PR TITLE
Add-puddletag.md

### DIFF
--- a/docs/sandbox/apps/puddletag.md
+++ b/docs/sandbox/apps/puddletag.md
@@ -1,0 +1,34 @@
+# Puddletag
+
+## What is it?
+
+[Puddletag](https://docs.puddletag.net/){: target=_blank rel="noopener noreferrer" } is an audio tag editor (primarily created) for GNU/Linux similar to the Windows program, Mp3tag. Unlike most taggers for GNU/Linux, it uses a spreadsheet-like layout so that all the tags you want to edit by hand are visible and easily editable.
+
+!!!info
+    By default, the role is protected behind your Authelia/SSO middleware. You will also have to log into the app itself. (Basic Auth)
+
+| Details     |             |             |
+|-------------|-------------|-------------|
+| [:material-home: Project home](https://docs.puddletag.net/){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-link-16: Docs](https://docs.puddletag.net/docs.html){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-mark-github-16: Github](https://github.com/Xirg/docker-puddletag){: .header-icons target=_blank rel="noopener noreferrer" }|
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-puddletag
+
+```
+
+### 2. URL
+
+- To access Puddletag, visit `https://puddletag._yourdomain.com_`
+
+### 3. Setup
+
+- Default login:
+  ``` { .yaml}
+  Username: "your user from accounts.yml"
+  Password: your_normal_password
+  ```
+
+- [:octicons-link-16: Documentation: Puddletag Docs](https://docs.puddletag.net/docs.html){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -89,6 +89,7 @@
   -  **[plextraktsync](../sandbox/apps/plextraktsync.md)**  - tag - `sandbox-plextraktsync`
   -  **[plex_utills](../sandbox/apps/plex_utills.md)**  - tag - `sandbox-plex_utills`
   -  **[privatebin](../sandbox/apps/privatebin.md)**  - tag - `sandbox-privatebin`
+  -  **[Puddletag](../sandbox/apps/puddletag.md)**  - tag - `sandbox-puddletag`
   -  **[pyload](../sandbox/apps/pyload.md)**  - tag - `pyload`
   -  **[python-plexlibrary](../sandbox/apps/python-plexlibrary.md)**  - tag - `python-plexlibrary`
   -  **[qbit_manage](../sandbox/apps/qbit_manage.md)**  - tag - `sandbox-qbit_manage`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,6 +251,7 @@ nav:
           - guacamole: sandbox/apps/guacamole.md
           - handbrake: sandbox/apps/handbrake.md
           - MakeMKV: sandbox/apps/makemkv.md
+          - Puddletag: sandbox/apps/puddletag.md
           - sabthrottle: sandbox/apps/sabthrottle.md
           - speedtest: sandbox/apps/speedtest.md
           - sqlitebrowser: sandbox/apps/sqlitebrowser.md


### PR DESCRIPTION
Add Puddletag page to docs, added ref in index and mkdocs.yml

- [x] App documentation page created
- [x] Reference added in `dogs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml`