### PR TITLE
Add Homarr to docs

### DIFF
--- a/docs/sandbox/apps/homarr.md
+++ b/docs/sandbox/apps/homarr.md
@@ -1,0 +1,45 @@
+# Homarr
+
+## What is it?
+
+[Homarr](https://www.homarr.org/){: target=_blank rel="noopener noreferrer" } is a simple and modern homepage for your server that helps you access all of your services in one place. It integrates with the services you use to display useful information or control them. It's easy to install and supports many different devices.
+
+- Integrates with services you use.
+- Search the web directly from your homepage.
+- Search overseerr directly from your homepage.
+- Real-time status indicator for every service.
+- Automatically finds icons while you type the name of a service.
+- Widgets that can display all types of information.
+
+!!!info
+    By default, the role is protected behind your Authelia/SSO middleware. You will also have to log into the app itself. 
+
+| Details     |             |             |             |
+|-------------|-------------|-------------|-------------|
+| [:material-home: Project home](https://homarr.dev/){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-link-16: Docs](https://homarr.dev/docs/introduction/manage-services){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-mark-github-16: Github](https://github.com/ajnart/homarr){: .header-icons target=_blank rel="noopener noreferrer" } | [:material-docker: Docker](https://hub.docker.com/r/ajnart/homarr/){: .header-icons target=_blank rel="noopener noreferrer" }|
+
+Recommended install types: Saltbox, Core
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-homarr
+
+```
+
+### 2. URL
+
+- To access homarr, visit `https://homarr._yourdomain.com_`
+
+### 3. Setup
+
+- Default login:
+
+  ``` { .yaml}
+
+  Password: your_normal_password
+
+  ```
+
+- [:octicons-link-16: Documentation: Homarr Docs](https://homarr.dev/docs/introduction/manage-services){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -46,6 +46,7 @@
   -  **[handbrake](../sandbox/apps/handbrake.md)**  - tag - `sandbox-handbrake`
   -  **[healthchecks](../sandbox/apps/healthchecks.md)**  - tag - `sandbox-healthchecks`
   -  **[heimdall](../sandbox/apps/heimdall.md)**  - tag - `sandbox-heimdall`
+  -  **[Homarr](../sandbox/apps/homarr.md)**  - tag - `sandbox-homarr`
   -  **[homebox](../sandbox/apps/homebox.md)**  - tag - `sandbox-homebox`
   -  **[influxdb](../sandbox/apps/influxdb.md)**  - tag - `sandbox-influxdb`
   -  **[invoiceninja](../sandbox/apps/invoiceninja.md)**  - tag - `sandbox-invoiceninja`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
         - Landing Pages:
           - VNStat: sandbox/apps/vnstat.md
           - heimdall: sandbox/apps/heimdall.md
+          - Homarr: sandbox/apps/homarr.md
         - Game Servers:
           - Minecraft: sandbox/apps/minecraft.md
           - Minecraft Bedrock: sandbox/apps/minecraft-bedrock.md


### PR DESCRIPTION
Adding docs for homarr. I added it to index.md, mkdocs.yml under landing pages, by heimdall, and created the page. 

- [x] App documentation page created
- [x] Reference added in `docs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml`
