### PR TITLE
Add Trackarr to docs

### DIFF
--- a/docs/sandbox/apps/trackarr.md
+++ b/docs/sandbox/apps/trackarr.md
@@ -1,0 +1,37 @@
+# Trackarr
+
+## What is it?
+
+[Trackarr](https://gitlab.com/cloudb0x/trackarr){: target=_blank rel="noopener noreferrer" } monitors tracker announce IRC channel, parses the announcements, and forwards those announcements to ARR PVRs (eg Sonarr/Radarr).
+
+!!!info
+    By default, the role is **NOT** protected behind your Authelia/SSO middleware. You will have to log into the app itself (basic auth).
+
+| Details     |             |             |             |
+|-------------|-------------|-------------|-------------|
+| [:material-home: Project home](https://gitlab.com/cloudb0x/trackarr){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-link-16: Docs](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-mark-github-16: Gitlab](https://gitlab.com/cloudb0x/trackarr){: .header-icons target=_blank rel="noopener noreferrer" } | [:material-docker: Docker](https://hub.docker.com/r/cloudb0x/trackarr){: .header-icons target=_blank rel="noopener noreferrer" }|
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-trackarr
+
+```
+
+### 2. URL
+
+- To access Trackarr, visit `https://trackarr._yourdomain.com_`
+
+### 3. Setup
+
+- Default login:
+
+  ``` { .yaml}
+  Username: "your user from accounts.yml"
+  Password: your_normal_password
+  ```
+
+You will need to set up your config file once the role has completed. [Here](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration/Sample) is an example config from the wiki that has a broader example of possible options and tracker configuration.
+
+- [:octicons-link-16: Documentation: Trackarr Docs](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/apps/trackarr.md
+++ b/docs/sandbox/apps/trackarr.md
@@ -14,16 +14,12 @@
 ### 1. Installation
 
 ``` shell
-
 sb install sandbox-trackarr
-
 ```
 
-### 2. URL
+The `trackarr` role will provision a config file with your pvr and server info. After you run the role, you will need to set up your config. [Here](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration/Sample) is an example config from the wiki that has a broader example of possible options and tracker configuration.
 
-- To access Trackarr, visit `https://trackarr._yourdomain.com_`
-
-### 3. Setup
+### 2. Setup
 
 - Default login:
 
@@ -32,6 +28,8 @@ sb install sandbox-trackarr
   Password: your_normal_password
   ```
 
-You will need to set up your config file once the role has completed. [Here](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration/Sample) is an example config from the wiki that has a broader example of possible options and tracker configuration.
+### 3. URL
+
+- To access Trackarr, visit `https://trackarr._yourdomain.com_`
 
 - [:octicons-link-16: Documentation: Trackarr Docs](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/apps/trackarr.md
+++ b/docs/sandbox/apps/trackarr.md
@@ -17,8 +17,6 @@
 sb install sandbox-trackarr
 ```
 
-The `trackarr` role will provision a config file with your pvr and server info. After you run the role, you will need to set up your config. [Here](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration/Sample) is an example config from the wiki that has a broader example of possible options and tracker configuration.
-
 ### 2. Setup
 
 - Default login:
@@ -27,6 +25,8 @@ The `trackarr` role will provision a config file with your pvr and server info. 
   Username: "your user from accounts.yml"
   Password: your_normal_password
   ```
+
+The `trackarr` role will provision a config file with your pvr and server info. After you run the role, you will need to set up your config. [Here](https://gitlab.com/cloudb0x/trackarr/-/wikis/Configuration/Sample) is an example config from the wiki that has a broader example of possible options and tracker configuration.
 
 ### 3. URL
 

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -120,6 +120,7 @@
   -  **[thelounge](../sandbox/apps/thelounge.md)**  - tag - `sandbox-thelounge`
   -  **[tika](../sandbox/apps/tika.md)**  - tag - `sandbox-tika`
   -  **[tqm](../sandbox/apps/tqm.md)**  - tag - `sandbox-tqm`
+  -  **[Trackarr](../sandbox/apps/trackarr.md)**  - tag - `sandbox-trackarr`
   -  **[traefik_robotstxt](../sandbox/apps/traefik_robotstxt.md)**  - tag - `sandbox-traefik_robotstxt`
   -  **[transmission](../sandbox/apps/transmission.md)**  - tag - `sandbox-transmission`
   -  **[transmissionvpn](../sandbox/apps/transmissionvpn.md)**  - tag - `sandbox-transmissionvpn`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
             - Rflood: sandbox/apps/rflood.md
             - Rfloodx: sandbox/apps/rfloodx.md
             - tqm: sandbox/apps/tqm.md
+            - Trackarr: sandbox/apps/trackarr.md
             - Transmission: sandbox/apps/transmission.md
             - Transmissionx: sandbox/apps/transmissionx.md
         - File Management:


### PR DESCRIPTION
Added page to apps for trackarr, ref to index and mkdocs.yml. Added a link to a config sample from the original wiki. 

- [x] App documentation page created
- [x] Reference added in `docs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml`

