### PR TITLE
fix qbittorrent warning and minor typo

### DIFF
--- a/docs/apps/qbittorrent.md
+++ b/docs/apps/qbittorrent.md
@@ -54,19 +54,20 @@ sb install qbittorrent
   - tick `Run external program on torrent completion` and paste this into the box: `/usr/bin/unrar x -r "%F/." "%F/"`
 
     ![Hard Disk Section Screenshot](../images/community/qbit_hdd.png)
-
+<!-- markdownlint-disable MD046 -->
 !!! Warning
-      Make sure to choose a strong username/password combination because by default qBittorrent's Web API is completely exposed to the internet!<br>
-      If someone guesses your qBit's credentials, they can, among other things, steal your tracker passkeys and delete torrents (data included).<br><br>
-      If you don't need the Web API exposed, you can do so using the [inventory system](/saltbox/inventory/) with
+      Make sure to choose a strong username/password combination because by default qBittorrent's Web API is completely exposed to the internet!  
+      If someone guesses your qBit's credentials, they can, among other things, steal your tracker passkeys and delete torrents (data included).  
+      If you don't need the API endpoints exposed, you can disable them using the [inventory system](/saltbox/inventory/) with
 
-``` { .yaml }
-       qbittorrent_traefik_api_enabled: false
-```
+      ``` { .yaml }
+      qbittorrent_traefik_api_enabled: false
+      ```
 
-and by rerunning the `qbittorrent` tag.
+      and by rerunning the `qbittorrent` tag.
+<!-- markdownlint-enable MD046 -->
 
 !!! Note
-      if you're using private trackers be sure to go to `Options` -> `BittTorrent` and uncheck everything in Privacy section.
+      if you're using private trackers be sure to go to `Options` -> `BitTorrent` and uncheck everything in Privacy section.
 
 - [:octicons-link-16: Documentation](https://github.com/qbittorrent/qBittorrent/wiki){: .header-icons target=_blank rel="noopener noreferrer" }


### PR DESCRIPTION
Pretty sure https://github.com/saltyorg/docs/commit/673019fe7982dce1934db7a5a64511ab994e0e63#diff-b3ffbf1be5ce283c9497066c498d2074fc8e2718551a835fcbf77d69b0242226L67-R67 has broken the warning I've added to the qbittorrent page a while ago, so this is a PR that fixes it.
I tried everything I thought of to make a markdownlint warning go away, but nothing. I think it's just the `!!! Warning` syntax that confuses him, so I added an exception for those lines. 

Also fixed a small typo while I was there.