### PR TITLE
Remove # in front of a command

### DIFF
--- a/docs/saltbox/install/install.md
+++ b/docs/saltbox/install/install.md
@@ -62,7 +62,7 @@ Make sure you fill out the following configuration files before proceeding. Each
 
 To edit [assuming you are still logged in as `root`]:
 
-    # nano /srv/git/saltbox/accounts.yml
+    nano /srv/git/saltbox/accounts.yml
 
 Contents:
 


### PR DESCRIPTION
Please describe the purpose of this Pull Request.

If you click the copy button it includes the # on nano accounts.yml