### PR TITLE
Add Homepage to docs

### DIFF
--- a/docs/sandbox/apps/homepage.md
+++ b/docs/sandbox/apps/homepage.md
@@ -1,0 +1,43 @@
+# Homepage
+
+## What is it?
+
+[Homepage](https://github.com/benphelps/homepage){: target=_blank rel="noopener noreferrer" } is a modern (fully static, fast), secure (fully proxied), customizable application dashboard with integrations for more than 25 services and translations for over 15 languages. Easily configured via YAML files (or discovery via docker labels).
+
+### Features
+
+- Fast! The entire site is statically generated at build time, so you can expect instant load times
+- Full i18n support with automatic language detection
+  - Translations for Catalan, Chinese, Dutch, Finnish, French, German, Hebrew, Hungarian, Malay, Norwegian Bokmål, Polish, Portuguese, Portuguese (Brazil), Romanian, Russian, Spanish, Swedish and Yue
+- Docker integration
+  - Container status (Running / Stopped) & statistics (CPU, Memory, Network)
+  - Automatic service discovery (via labels)
+- Service integration
+  - Sonarr, Radarr, Readarr, Prowlarr, Bazarr, Lidarr, Emby, Jellyfin, Tautulli, Plex and more
+
+!!!info
+    By default, the role is protected behind your Authelia/SSO middleware.
+
+| Details     |             |             |
+|-------------|-------------|-------------|
+| [:material-home: Project home](https://gethomepage.dev/){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-link-16: Docs](https://gethomepage.dev/en/configs/services/){: .header-icons target=_blank rel="noopener noreferrer" } | [:octicons-mark-github-16: Github](https://github.com/benphelps/homepage){: .header-icons target=_blank rel="noopener noreferrer" }|
+
+Recommended install types: Saltbox, Core, Mediabox
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-homepage
+
+```
+
+### 2. URL
+
+- To access Homepage, visit `https://homepage._yourdomain.com_`
+
+### 3. Setup
+
+This role will add both the homepage container, and the homepage-docker-socket-proxy container. To add services and bookmarks etc. you edit your config files found at `/opt/homepage/config/`. There are several example services and widgets included in the role, just uncomment and fill them in appropriately. The webui will reload and it will be visible shortly after. No need to restart the container.
+
+- [:octicons-link-16: Documentation: Homepage Docs](https://gethomepage.dev/en/configs/services/){: .header-icons target=_blank rel="noopener noreferrer" }

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -48,6 +48,7 @@
 - **[heimdall](../sandbox/apps/heimdall.md)**  - tag - `sandbox-heimdall`
 - **[Homarr](../sandbox/apps/homarr.md)**  - tag - `sandbox-homarr`
 - **[homebox](../sandbox/apps/homebox.md)**  - tag - `sandbox-homebox`
+- **[homepage](../sandbox/apps/homepage.md)**  - tag - `sandbox-homepage`
 - **[influxdb](../sandbox/apps/influxdb.md)**  - tag - `sandbox-influxdb`
 - **[invoiceninja](../sandbox/apps/invoiceninja.md)**  - tag - `sandbox-invoiceninja`
 - **[jdownloader2](../sandbox/apps/jdownloader2.md)**  - tag - `sandbox-jdownloader2`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
           - VNStat: sandbox/apps/vnstat.md
           - heimdall: sandbox/apps/heimdall.md
           - Homarr: sandbox/apps/homarr.md
+          - Homepage: sandbox/apps/homepage.md
         - Game Servers:
           - Minecraft: sandbox/apps/minecraft.md
           - Minecraft Bedrock: sandbox/apps/minecraft-bedrock.md


### PR DESCRIPTION
Adding homepage to docs. Added ref to homepage in both index.md and mkdocs.yml. Added page under ...apps.

- [x] App documentation page created
- [x] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [x] Reference added in `docs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml` nav menu
