### PR TITLE
Inventory: Streamline

### DIFF
--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -48,18 +48,27 @@ The variables that can be used for customization within the Inventory are listed
     /opt/sandbox/roles/<role_name>/defaults/main.yml
     ```
 
-=== "Something Missing?"
+=== "Docker Parameters Reference"
 
-    !!! example inline end ""
-        
-        Some variables, though not listed, are implicitly available. Example:
+    !!! example inline end "Example"
+    
+        To obtain a `shm_size` variable for Plex, simply prepend `plex_docker_` to the parameter name: 
+      
         ```yaml
-        overseerr_docker_dns_servers
+        plex_docker_shm_size
         ```
 
-    In some cases, usually resulting from incomplete role migration, certain settings may not be currently exposed for use in the Inventory system.
+    For use cases involving Docker parameters beyond those exposed in the role files, it is still possible to construct usable Saltbox variables. The following resources provide the required syntax elements:
 
-    If you require additional functionality, feel free to create an issue on the [main repository](https://github.com/saltyorg/Saltbox/) and we will consider accommodating it.
+    <sub><https://github.com/saltyorg/Saltbox/blob/master/resources/tasks/docker/create_docker_container.yml></sub>
+
+    <sub><https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html></sub>
+
+=== "Something Missing?"
+
+    In some cases, usually resulting from incomplete role migration, certain settings may not be exposed for use in the Inventory system. 
+
+    Should you require additional functionality, feel free to create an issue on the [main repository](https://github.com/saltyorg/Saltbox/) and we will consider accommodating it.
 
 ## Demo
 

--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -118,9 +118,9 @@ A common use for additions is to specify extra Docker mappings or flags. Let's e
 ```yaml linenums="87" hl_lines="7" title="https://github.com/saltyorg/Sandbox/blob/master/roles/code_server/defaults/main.yml#L87"
 # Volumes
 code_server_docker_volumes_default:
-  - "{{ code_server_paths_location }}/project:/home/code_server/project"
-  - "{{ code_server_paths_location }}/.config:/home/code_server/.config"
-  - "{{ code_server_paths_location }}/.local:/home/code_server/.local"
+  - "{{ code_server_paths_location }}/project:/home/coder/project"
+  - "{{ code_server_paths_location }}/.config:/home/coder/.config"
+  - "{{ code_server_paths_location }}/.local:/home/coder/.local"
   - "{{ server_appdata_path }}:/host_opt"
 code_server_docker_volumes_custom: []
 ```

--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -132,13 +132,10 @@ To expose additional host locations (in this case, `/srv` and our home directory
 ```yaml
 code_server_docker_volumes_custom:
   - "/srv:/host_srv"
-  - "{{ user_paths_home_location }}:{{ user_paths_home_location }}" # (1)!
-
+  - "/home:/host_home"
 ```
 
-1. On this hypothetical Saltbox host, the default of "seed" was kept as the configured user, so `{{ user_paths_home_location }}` will be rendered into `/home/seed`.
-
-The container will then be created with the new volumes included, and the corresponding locations will be accessible to code-server via `/host_srv` and `/home/seed`.
+The container will then be created with the new volumes included, and the target locations will be accessible to code-server at `/host_srv` and `/host_home`.
 
 ## Additional Examples
 

--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -1,39 +1,78 @@
 # Inventory
 
-Advanced use cases that would normally require editing roles can now be handled through the inventory system instead.
+The inventory system offers a centralized approach to customizing roles, allowing manipulation of variables without directly editing the roles themselves. This ensures persistent configurations while avoiding conflicts during git merge operations.
 
-You will enter your new values in:
+## Modifying Variables
+
+Enter your new values in:
 
 ```shell
 /srv/git/saltbox/inventories/host_vars/localhost.yml
 ```
 
-This implementation avoids git merge conflicts when updating Saltbox.
+Changes take effect after deploying the corresponding role(s) using the `sb install` command prefix. Examples:
 
-Any variables defined in role files are available to be overridden by the user.
+<div class="grid" markdown>
 
-These roles files can be found on your saltbox machine as:
-```
-/srv/git/saltbox/roles/<role_name>/defaults/main.yml
-```
-or 
-```
-/opt/sandbox/roles/<role_name>/defaults/main.yml
+```shell
+sb install shell
 ```
 
-These files can also be reviewed in the github repo for [saltbox](https://github.com/saltyorg/Saltbox/tree/master/roles) and [sandbox](https://github.com/saltyorg/Saltbox/tree/master/roles).
+```shell
+sb install sonarr,sandbox-code_server
+```
 
-Should you require additional functionality then by all means create an issue on the [main repository](https://github.com/saltyorg/Saltbox/) and we'll look at accommodating it.
+</div>
 
-## 'Default' variables
+## Finding Available Variables
 
-!!! info
-    For the purpose of this guide, this refers to variables that are defined with actual data and are not empty (i.e., not followed by an empty string `""`, list `[]` or dictionary `{}`), as well as all variables suffixed with `_default` even if they are empty, in a given role's _defaults_ YAML file. Using the inventory to define one of these variables is therefore considered an override, as it will cause the value(s) originally stored in it to be omitted.
+The variables that can be used for customization within the Inventory are listed in the following locations:
 
-A common use for these overrides will be specifying the version of the Docker image to be used, so let's see how that's done by looking into `/srv/git/saltbox/roles/sonarr/defaults/main.yml` around line 85:
+=== "GitHub File View"
 
-``` yaml
-################################
+    Saltbox: &nbsp; &nbsp; [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/tree/master/roles/](https://github.com/saltyorg/Saltbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
+
+    Sandbox: &nbsp; [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Sandbox/tree/master/roles/](https://github.com/saltyorg/Sandbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
+
+=== "File Path on Saltbox Host"
+
+    !!! warning inline end "Never Edit These Files"
+    
+        Updates will overwrite your changes. Use the inventory system instead.
+
+    ```shell
+    /srv/git/saltbox/roles/<role_name>/defaults/main.yml
+    ```
+
+    ```shell
+    /opt/sandbox/roles/<role_name>/defaults/main.yml
+    ```
+
+=== "Something Missing?"
+
+    !!! example inline end ""
+        
+        Some variables, though not listed, are implicitly available. Example:
+        ```yaml
+        overseerr_docker_dns_servers
+        ```
+
+    In some cases, usually resulting from incomplete role migration, certain settings may not be currently exposed for use in the Inventory system.
+
+    If you require additional functionality, feel free to create an issue on the [main repository](https://github.com/saltyorg/Saltbox/) and we will consider accommodating it.
+
+## Demo
+
+Let's explore two example use cases for customizing roles using variables in the Saltbox Inventory.
+
+### Override
+
+??? tip inline end "\`default\` Variables"
+    Variables suffixed with `_default` and variables predefined with non-empty values (specifically, not followed by a blank, an empty string `""`, list `[]` or dictionary `{}`) fall under this category. Using the Inventory to define one of these variables is therefore considered an override, as it will cause the value(s) originally stored in it to be discarded.
+
+A common use for overrides will be specifying the version of the Docker image to be used. Let's see how that's done by looking into `/srv/git/saltbox/roles/sonarr/defaults/main.yml` around line 89:
+
+```yaml linenums="83" hl_lines="10" title="https://github.com/saltyorg/Saltbox/blob/master/roles/sonarr/defaults/main.yml#L89"
 # Docker
 ################################
 
@@ -48,51 +87,67 @@ sonarr_docker_image: "{{ lookup('vars', sonarr_name + '_docker_image_repo', defa
                          + ':' + lookup('vars', sonarr_name + '_docker_image_tag', default=sonarr_docker_image_tag) }}"
 ```
 
-Note: `sonarr_docker_image_tag: "release"`
+Note: `sonarr_docker_image_tag: "release"`. 
 
-For Sonarr, Saltbox will use the Docker image `cr.hotio.dev/hotio/sonarr:release` by default.
+By default, Saltbox will use `cr.hotio.dev/hotio/sonarr:release` as the Sonarr Docker image.
 
-If you wanted to change that to "nightly", you'd add this line to `/srv/git/saltbox/inventories/host_vars/localhost.yml`:
+Should we choose to switch to "nightly" versions, we can add the following line to `localhost.yml`:
 
-``` yaml
+```yaml
 sonarr_docker_image_tag: "nightly"
 ```
 
-Which would override the default [`release`] and result in Saltbox using the `cr.hotio.dev/hotio/sonarr:nightly` Docker image instead, without you modifying this file. If you update Saltbox and this file is replaced, your tag change to `nightly` remains in effect.
+This will cause Saltbox to use the `cr.hotio.dev/hotio/sonarr:nightly` Docker image, overriding the default: [`release`]. When we update Saltbox, our tag change to `nightly` will remain in effect.
 
-## 'Custom' variables
+### Addition
 
-!!! info
-    Suffixed with `_custom`, these are available in case you wish to add values to a list or dictionary type setting, without dropping existing values.
+??? tip inline end "\`custom\` Variables"
+    Variables suffixed with `_custom` and variables defined with an empty string fall under this category. Respectively, this is used to add custom values to a list or a dictionary without discarding existing values, and to assign a value to an exposed role-specific setting.
 
-Typical use would be to pass new Docker parameters:
+A common use for additions is to specify extra Docker mappings or flags. Let's examine how to give our [code-server](../../sandbox/apps/code_server) container access to more locations on the host:
+
+```yaml linenums="87" hl_lines="7" title="https://github.com/saltyorg/Sandbox/blob/master/roles/code_server/defaults/main.yml#L87"
+# Volumes
+code_server_docker_volumes_default:
+  - "{{ code_server_paths_location }}/project:/home/code_server/project"
+  - "{{ code_server_paths_location }}/.config:/home/code_server/.config"
+  - "{{ code_server_paths_location }}/.local:/home/code_server/.local"
+  - "{{ server_appdata_path }}:/host_opt"
+code_server_docker_volumes_custom: []
+```
+
+Note the list syntax. Since we want the container to preserve existing volumes, the `_docker_volumes_default` list should not be overridden. Instead, we use the `_docker_volumes_custom` list.
+
+To expose additional host locations (in this case, `/srv` and our home directory), we can add custom volumes to the list using the following syntax in the Inventory:
 
 ```yaml
-#### Extra mounts for Sonarr containers ####
-sonarr_docker_volumes_custom:
-  - "/mnt/unionfs/Media/Anime:/anime"
-  - "/mnt/unionfs/Media/Kids:/kids"
+code_server_docker_volumes_custom:
+  - "/srv:/host_srv"
+  - "{{ user_paths_home_location }}:{{ user_paths_home_location }}" # (1)!
+
 ```
+
+1. On this hypothetical Saltbox host, the default of "seed" was kept as the configured user, so `{{ user_paths_home_location }}` will be rendered into `/home/seed`.
+
+The container will then be created with the new volumes included, and the corresponding locations will be accessible to code-server via `/host_srv` and `/home/seed`.
 
 ## Additional Examples
 
-### Various
-
-```yaml
+```yaml title="Various"
 ##### Plex Ports for local access#####
 plex_open_main_ports: true
 plex_open_local_ports: true
 
 ##### Plex Container Variables ####
-plex_docker_image_tag: beta
-plex_open_main_ports: true
+plex_docker_image_pull: false # (1)!
+plex_docker_image_tag: beta # (2)!
 
 #### Examples of specified container images: ####
 radarr_docker_image_tag: nightly
 sonarr_docker_image_tag: nightly
 petio_docker_image_tag: nightly
 
-#### BW Limiting speeds ####
+#### Bandwidth limiting ####
 transfer_docker_envs_custom:
   MAX_UPLOAD_SIZE: "104857546"
 
@@ -114,17 +169,24 @@ shell_zsh_zshrc_block_custom: |
   alias sbi='sb install'
 ```
 
+1. Can be used to version-pin the image to the current container's version (as long as the image is never pulled by other means)
+
+2. Will version-lock if the tag designates a specific version.
+
 ### Authelia App Bypass
 
-Some may not want the additional layer of security that Authelia supplies, good news is that it can be disabled with a simple override. To determine which apps by default are included in Authelia, one can run this command or similar:
+Some users may not want the additional layer of security that Authelia provides. The good news is that it can be disabled through a simple override.
 
-```shell
-grep -Ril '_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"' /srv/git/saltbox/roles /opt/sandbox/roles | awk 'BEGIN{RS="roles/"; FS="/defaults"}NF>1{print $1}' | sort -u
-```
+!!! tip ""
+    To determine which apps are included in Authelia by default, you can run this command or a similar one:
 
-#### Override example
+    ```shell
+    grep -Ril '_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"' /srv/git/saltbox/roles /opt/sandbox/roles | awk 'BEGIN{RS="roles/"; FS="/defaults"}NF>1{print $1}' | sort -u
+    ```
 
-```yaml
+!!! danger "Before proceeding, ensure that fallback measures are in place to prevent unauthorized access to any of your apps."
+
+```yaml title="Override Example"
 ### Authelia App Bypass ###
 sonarr_traefik_sso_middleware: ""
 tautulli_traefik_sso_middleware: ""
@@ -133,15 +195,15 @@ nzbget_traefik_sso_middleware: ""
 prowlarr_traefik_sso_middleware: ""`
 ```
 
-After making this change in the Inventory file, simply run the appropriate role command in order to disable Authelia on that specific app. Reminder you can run multiple tags at once.
+After making this change in the Inventory file, simply run the appropriate role command to disable Authelia on that specific app. Remember, you can run multiple tags at once.
 
 ### Authorize with App Credentials
 
-#### Inject an Authorization header - Traefik performs basic auth with the backend app
+__Inject an Authorization header - Traefik performs basic auth with the backend app__
 
-This allows you to keep basic auth enabled within apps but not have the hassle of entering the credentials manually. The authorization header is only inserted if the request is authorized through the SSO middleware (Authelia) and is not applied to the API endpoint(s).
+This will allow you to keep basic auth enabled within apps while avoiding the hassle of entering the credentials manually. The authorization header is only inserted if the request is authorized through the SSO middleware (Authelia) and is not applied to the API endpoint(s).
 
-Use [this tool](https://www.blitter.se/utils/basic-authentication-header-generator/) to generate the header contents based on your credentials.
+You can use [this tool](https://www.blitter.se/utils/basic-authentication-header-generator/) to generate the header contents based on your credentials.
 
 ```yaml
 sonarr_docker_labels_custom:
@@ -151,29 +213,29 @@ sonarr_traefik_middleware_custom: "appAuth"
 
 ### Subdomain Customization
 
-#### Overrides
+=== "Overrides"
 
-```yaml
-#### Make Organizr available only at the base domain ####
-organizr_web_subdomain: ""
+    ```yaml
+    #### Make Organizr available only at the base domain ####
+    organizr_web_subdomain: ""
+    
+    #### Make Tautulli available only at `stats.domain.tld` ####
+    tautulli_web_subdomain: "stats"
+    ```
 
-#### Make Tautulli available only at `stats.domain.tld` ####
-tautulli_web_subdomain: "stats"
-```
+=== "Additions"
 
-#### Additions
-
-!!! warning
-    The following examples require adding DNS records manually.
-
-```yaml
-#### Make Organizr available at both `organizr.domain.tld` and `domain.tld` ####
-organizr_docker_labels_custom:
-  traefik.http.routers.organizr-http.rule: "Host(`{{ organizr_web_subdomain + '.' + organizr_web_domain }}`) || Host(`{{ organizr_web_domain }}`)"
-  traefik.http.routers.organizr.rule: "Host(`{{ organizr_web_subdomain + '.' + organizr_web_domain }}`) || Host(`{{ organizr_web_domain }}`)"
-
-#### Make Overseerr available at both `overseerr.domain.tld` and `requests.domain.tld` ####
-overseerr_docker_labels_custom:
-  traefik.http.routers.overseerr-http.rule: "Host(`{{ overseerr_web_subdomain + '.' + overseerr_web_domain }}`) || Host(`{{ 'requests.' + overseerr_web_domain }}`)"
-  traefik.http.routers.overseerr.rule: "Host(`{{ overseerr_web_subdomain + '.' + overseerr_web_domain }}`) || Host(`{{ 'requests.' + overseerr_web_domain }}`)"
-```
+    !!! warning ""
+        The following examples require adding DNS records manually.
+    
+    ```yaml
+    #### Make Organizr available at both `organizr.domain.tld` and `domain.tld` ####
+    organizr_docker_labels_custom:
+      traefik.http.routers.organizr-http.rule: "Host(`{{ organizr_web_subdomain + '.' + organizr_web_domain }}`) || Host(`{{ organizr_web_domain }}`)"
+      traefik.http.routers.organizr.rule: "Host(`{{ organizr_web_subdomain + '.' + organizr_web_domain }}`) || Host(`{{ organizr_web_domain }}`)"
+    
+    #### Make Overseerr available at both `overseerr.domain.tld` and `requests.domain.tld` ####
+    overseerr_docker_labels_custom:
+      traefik.http.routers.overseerr-http.rule: "Host(`{{ overseerr_web_subdomain + '.' + overseerr_web_domain }}`) || Host(`{{ 'requests.' + overseerr_web_domain }}`)"
+      traefik.http.routers.overseerr.rule: "Host(`{{ overseerr_web_subdomain + '.' + overseerr_web_domain }}`) || Host(`{{ 'requests.' + overseerr_web_domain }}`)"
+    ```


### PR DESCRIPTION
Finally got around to setting up private mkdocs and this is my first victim. Somewhat ChatGPT assisted so some significant structural and phraseology changes. 

@ chaz, owine: not my intention to cramp your style, so I'm not necessarily suggesting this be merged as is. It's a proposal—keep what you like / restore what you liked better.

Key changes:
- bring into focus some steps that users often overlook
- make the content more concise and tuck optional info in formatting, to cater to skim readers


