### PR TITLE
Firefox role (Sandbox) + add mkdocs-material privacy plugin

### DIFF
--- a/docs/advanced/healthchecks.md
+++ b/docs/advanced/healthchecks.md
@@ -1,6 +1,6 @@
 # Container Healthchecks
 
-Saltbox can set a custom healthcheck on a Docker container via the inventory system.
+Saltbox can set a custom healthcheck on a Docker container via the [inventory system](../saltbox/inventory/index.md).
 
 The syntax for this
 
@@ -88,6 +88,13 @@ duplicati_docker_healthcheck:
 
 elasticsearch_docker_healthcheck:
   test: ["CMD", "curl", "--fail", "http://localhost:9200"]
+  interval: 10s
+  timeout: 5s
+  retries: 10
+  start_period: 10s
+  
+firefox_docker_healthcheck:
+  test: ["CMD", "wget", "--spider", "http://localhost:{{ firefox_web_port }}"]
   interval: 10s
   timeout: 5s
   retries: 10

--- a/docs/sandbox/apps/firefox.md
+++ b/docs/sandbox/apps/firefox.md
@@ -45,7 +45,7 @@ The role supports VNC access over an SSH tunnel (local port forwarding) to Saltb
     1. `-L localhost:5900:firefox:5900`: This part specifies local port forwarding. It tells SSH to listen on port 5900 on your local machine and forward any traffic to the firefox Docker container on port 5900 on the Saltbox host. In other words, it sets up a tunnel between your local port 5900 and the container's port 5900.  
         Complete the command with your usual SSH info: `USERNAME@SALTBOX_EXTERNAL_IP -p SSH_PORT`.
 
-While the tunnel is active, you can use a VNC client to access the GUI via the address `firefox:5900`.
+While the tunnel is active, you can use a VNC client to access the GUI via the address `localhost:5900`.
 
 ## Configuration
 

--- a/docs/sandbox/apps/firefox.md
+++ b/docs/sandbox/apps/firefox.md
@@ -1,0 +1,70 @@
+# Firefox
+
+## What is it?
+
+[Mozilla Firefox](https://www.mozilla.org/firefox/) is a free and open-source web browser developed by Mozilla Foundation and its subsidiary, Mozilla Corporation.
+
+The GUI of the application is accessed through a modern web browser (no installation or configuration needed on the client side) or via any VNC client.
+
+<div class="grid" style="grid-template-columns: repeat(auto-fit,minmax(10.5rem,1fr));" markdown>
+
+[:material-bookshelf: Project Docs](https://github.com/jlesage/docker-firefox#readme){ .md-button .md-button--stretch }
+
+[:material-git: GitHub Repo](https://github.com/jlesage/docker-firefox){ .md-button .md-button--stretch }
+
+[:material-docker: Docker Hub](https://hub.docker.com/r/jlesage/firefox){ .md-button .md-button--stretch }
+
+</div>
+
+## Deployment
+
+``` shell
+sb install sandbox-firefox
+```
+
+## Usage
+
+!!! info inline end "Downloads Save Location"
+    ```
+    /mnt/unionfs/downloads/firefox
+    ```
+
+### <span class="icon-indent-right"></span> Web
+
+Visit `https://firefox._yourdomain.com_`.
+
+### <span class="icon-indent-right"></span> VNC
+
+The role supports VNC access over an SSH tunnel (local port forwarding) to Saltbox.
+
+!!! example "Example Command on Local Machine <span style="float:right;color:#00bfa5">:material-fire: Some VNC apps have this functionality built-in!</span>"
+    ```shell
+    ssh -L localhost:5900:firefox:5900 seed@203.0.113.1 -p 8843 # (1)!
+    ```
+
+    1. `-L localhost:5900:firefox:5900`: This part specifies local port forwarding. It tells SSH to listen on port 5900 on your local machine and forward any traffic to the firefox Docker container on port 5900 on the Saltbox host. In other words, it sets up a tunnel between your local port 5900 and the container's port 5900.  
+        Complete the command with your usual SSH info: `USERNAME@SALTBOX_EXTERNAL_IP -p SSH_PORT`.
+
+While the tunnel is active, you can use a VNC client to access the GUI via the address `firefox:5900`.
+
+## Configuration
+
+### <span class="icon-indent-right"></span> Security
+
+By default, web access is restricted by Authelia, and VNC access is secured through SSH authentication; hence, no VNC password is configured. If you wish to add this extra layer of security, the process is straightforward:
+
+1. Run the following command:
+   ```shell
+   $EDITOR /opt/firefox/.vncpass_clear
+   ```
+
+2. Enter your desired password (up to 8 characters in length) and save the file.
+
+3. Restart the container.
+
+### <span class="icon-indent-right"></span> Misc
+
+Various properties [:octicons-link-16:][envs] can be customized in `/opt/firefox/.env`. To apply changes to this file, redeploy the container.
+
+  [envs]: https://github.com/jlesage/docker-firefox#environment-variables "Go to the breakdown of environment variables available in the container"
+    

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -33,6 +33,7 @@
 - **[filebot](../sandbox/apps/filebot.md)**  - tag - `sandbox-filebot`
 - **[filebrowser](../sandbox/apps/filebrowser.md)**  - tag - `sandbox-filebrowser`
 - **[filezilla](../sandbox/apps/filezilla.md)**  - tag - `sandbox-filezilla`
+- **[firefox](../sandbox/apps/firefox.md)**  - tag - `sandbox-firefox`
 - **[flaresolverr](../sandbox/apps/flaresolverr.md)**  - tag - `sandbox-flaresolverr`
 - **[freshrss](../sandbox/apps/freshrss.md)**  - tag - `sandbox-freshrss`
 - **[funkwhale](../sandbox/apps/funkwhale.md)**  - tag - `sandbox-funkwhale`

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,22 +3,28 @@
 }
 
 .md-typeset table:not([class]) {
-   display: table;
+  display: table;
+}
+
+.md-typeset .md-button--stretch {
+  width: 100%;
 }
 
 @media only screen and (min-width: 76.25em) {
   .md-main__inner {
     max-width: 80%;
   }
+
   .md-sidebar--primary {
     margin-left: 0;
     left: 0;
   }
+
   .md-sidebar--secondary {
     right: 0;
     margin-left: 0;
     -webkit-transform: none;
-    transform: none;   
+    transform: none;
   }
 }
 
@@ -30,6 +36,14 @@
     transform: scale(1.15);
   }
 }
+
 .heart {
   animation: heart 1000ms infinite;
+}
+
+.icon-indent-right::before {
+  content: "\2BA9";
+  color: var(--md-accent-fg-color);
+  padding-left: 1em;
+  padding-right: 0.25em;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,11 @@ theme:
         name: Switch to system preference
 
 plugins:
+  - privacy:
+      links_attr_map:
+        rel: noreferrer
+        target: _blank
+      links_noopener: true
   - search:
       lang: en
   - meta

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
         - General:
           - AdGuard Home: sandbox/apps/adguardhome.md
           - Cherry: sandbox/apps/cherry.md
+          - Firefox: sandbox/apps/firefox.md
           - Homebox: sandbox/apps/homebox.md
           - Joplin: sandbox/apps/joplin.md
           - Linkding: sandbox/apps/linkding.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ theme:
 
 plugins:
   - privacy:
+      assets: false
       links_attr_map:
         rel: noreferrer
         target: _blank


### PR DESCRIPTION
Fully previewed and tested using the Insiders edition.

- [x] App documentation page created
- [x] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [x] Reference added in `docs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml` nav menu
- [x] Healthcheck sample added in `docs/advanced/healthchecks.md`

Also, `extra.css` got linted as I added some things.
