### PR TITLE
Added settings for Bazarr to limit API calls

### DIFF
--- a/docs/apps/bazarr.md
+++ b/docs/apps/bazarr.md
@@ -28,13 +28,4 @@ sb install bazarr
 
 There are some settings that - depending on your specific setup - should be adapted to reduce API calls down to a managable level.
 
-[:octicons-link-16: Performance Tuning](https://wiki.bazarr.media/Additional-Configuration/Performance-Tuning/) contains some - especially of note:
-`Settings` => `Subtitles` => `Performance / Optimization` Disable `Use Embedded Subtitles` Embedded subtitles are subtitles that are in the video container (mkv, mp4, etc) Bazarr needs to look inside the video container to know which subtitles are in it this can be resource intensive for some low powered devices and also give you issues with API Limits if you store your media on the cloud.
-
-In addition:
-
-- `Settings` => `Languages` => `Embedded Tracks Language` Disable `Deep analyze media file to get audio tracks language.`
-
-- `Settings` => `Subtitles` => `Performance / Optimization` Enable `Skip video file hash calculation` - (Possibly depending on the cloud backend) it seems to trigger a full read by multiple API calls instead of just getting the hash
-
-- `Settings` => `Subtitles` => `Post-Processing` Disable `Automatic Subtitles Synchronization` - This one hurts quite a bit to disable, but if you are downloading multiple subtitles (like you just downloaded multiple series and they got pushed to the cloud by cloudplow before Bazarr pulled subs; or subs got released for a whole series en block, etc.) it will trigger Bazarr to download and analyze a whole bunch of files possibly triggering tens of thousands of API-calls.
+Please refer to the official documentation for an explanation of the settings. Some - potentially out of date(!) - settings are documented in the [FAQs](../faq/Bazarr.md).

--- a/docs/apps/bazarr.md
+++ b/docs/apps/bazarr.md
@@ -25,3 +25,11 @@ sb install bazarr
 - [:octicons-link-16: Documentation](https://wiki.bazarr.media/){: .header-icons }
 
 - [:octicons-link-16: TraSH Guides](https://trash-guides.info/Bazarr/)
+
+There are some settings that - depending on your specific setup - should be adapted to reduce API calls down to a managable level. 
+[:octicons-link-16: Performance Tuning](https://wiki.bazarr.media/Additional-Configuration/Performance-Tuning/) contains some - especially of note: 
+`Settings` => `Subtitles` => `Performance / Optimization` Disable `Use Embedded Subtitles` Embedded subtitles are subtitles that are in the video container (mkv, mp4, etc) Bazarr needs to look inside the video container to know which subtitles are in it this can be resource intensive for some low powered devices and also give you issues with API Limits if you store your media on the cloud.
+In addition:
+`Settings` => `Languages` => `Embedded Tracks Language` Disable `Deep analyze media file to get audio tracks language.`
+`Settings` => `Subtitles` => `Performance / Optimization` Enable `Skip video file hash calculation` - (Possibly depending on the cloud backend) it seems to trigger a full read by multiple API calls instead of just getting the hash
+`Settings` => `Subtitles` => `Post-Processing` Disable `Automatic Subtitles Synchronization` - This one hurts quite a bit to disable, but if you are downloading multiple subtitles (like you just downloaded multiple series and they got pushed to the cloud by cloudplow before Bazarr pulled subs; or subs got released for a whole series en block, etc.) it will trigger Bazarr to download and analyze a whole bunch of files possibly triggering tens of thousands of API-calls. 

--- a/docs/apps/bazarr.md
+++ b/docs/apps/bazarr.md
@@ -26,10 +26,15 @@ sb install bazarr
 
 - [:octicons-link-16: TraSH Guides](https://trash-guides.info/Bazarr/)
 
-There are some settings that - depending on your specific setup - should be adapted to reduce API calls down to a managable level. 
-[:octicons-link-16: Performance Tuning](https://wiki.bazarr.media/Additional-Configuration/Performance-Tuning/) contains some - especially of note: 
+There are some settings that - depending on your specific setup - should be adapted to reduce API calls down to a managable level.
+
+[:octicons-link-16: Performance Tuning](https://wiki.bazarr.media/Additional-Configuration/Performance-Tuning/) contains some - especially of note:
 `Settings` => `Subtitles` => `Performance / Optimization` Disable `Use Embedded Subtitles` Embedded subtitles are subtitles that are in the video container (mkv, mp4, etc) Bazarr needs to look inside the video container to know which subtitles are in it this can be resource intensive for some low powered devices and also give you issues with API Limits if you store your media on the cloud.
+
 In addition:
-`Settings` => `Languages` => `Embedded Tracks Language` Disable `Deep analyze media file to get audio tracks language.`
-`Settings` => `Subtitles` => `Performance / Optimization` Enable `Skip video file hash calculation` - (Possibly depending on the cloud backend) it seems to trigger a full read by multiple API calls instead of just getting the hash
-`Settings` => `Subtitles` => `Post-Processing` Disable `Automatic Subtitles Synchronization` - This one hurts quite a bit to disable, but if you are downloading multiple subtitles (like you just downloaded multiple series and they got pushed to the cloud by cloudplow before Bazarr pulled subs; or subs got released for a whole series en block, etc.) it will trigger Bazarr to download and analyze a whole bunch of files possibly triggering tens of thousands of API-calls. 
+
+- `Settings` => `Languages` => `Embedded Tracks Language` Disable `Deep analyze media file to get audio tracks language.`
+
+- `Settings` => `Subtitles` => `Performance / Optimization` Enable `Skip video file hash calculation` - (Possibly depending on the cloud backend) it seems to trigger a full read by multiple API calls instead of just getting the hash
+
+- `Settings` => `Subtitles` => `Post-Processing` Disable `Automatic Subtitles Synchronization` - This one hurts quite a bit to disable, but if you are downloading multiple subtitles (like you just downloaded multiple series and they got pushed to the cloud by cloudplow before Bazarr pulled subs; or subs got released for a whole series en block, etc.) it will trigger Bazarr to download and analyze a whole bunch of files possibly triggering tens of thousands of API-calls.

--- a/docs/faq/Bazarr.md
+++ b/docs/faq/Bazarr.md
@@ -1,0 +1,16 @@
+# Bazarr
+
+## Settings to limit API calls
+
+All settings are documented in the [official docs](https://wiki.bazarr.media) - though most of the time the impact on Saltbox setups needs to be inferred.
+Especially useful: [:octicons-link-16: Performance Tuning](https://wiki.bazarr.media/Additional-Configuration/Performance-Tuning/)
+
+### Some settings of note - AS OF 22ND OCTOBER 2023 - MIGHT BE OUTDATED IF YOU READ THIS LATER
+
+- `Settings` => `Subtitles` => `Performance / Optimization` Disable `Use Embedded Subtitles` Embedded subtitles are subtitles that are in the video container (mkv, mp4, etc) Bazarr needs to look inside the video container to know which subtitles are in it, causing issues with API Limits 
+
+- `Settings` => `Languages` => `Embedded Tracks Language` Disable `Deep analyze media file to get audio tracks language.`
+
+- `Settings` => `Subtitles` => `Performance / Optimization` Enable `Skip video file hash calculation` - (Possibly depending on the cloud backend) it seems to trigger a full read by multiple API calls instead of just getting the hash
+
+- `Settings` => `Subtitles` => `Post-Processing` Disable `Automatic Subtitles Synchronization` - This one hurts quite a bit to disable, but if you are downloading multiple subtitles (like you just downloaded multiple series and they got pushed to the cloud by cloudplow before Bazarr pulled subs; or subs got released for a whole series en block, etc.) it will trigger Bazarr to download and analyze a whole bunch of files possibly triggering tens of thousands of API-calls.


### PR DESCRIPTION
Added several settings for Bazarr to limit API calls - based solely on preliminary testing on my machine. 

Would appreciate some fact checking; and/or solutions that don't involve disabling automatic synchronization. But considering there was no info in the docs I thought I'd make a start. 