### PR TITLE
Update Wrapperr docs for clarity and auth info

### DIFF
--- a/docs/sandbox/apps/wrapperr.md
+++ b/docs/sandbox/apps/wrapperr.md
@@ -2,12 +2,11 @@
 
 ## What is it?
 
-[Wrapperr](https://github.com/aunefyren/wrapperr) is a website-based platform and API for collecting user stats within a set timeframe using Tautulli. The data is displayed as a statistics-summary, sort of like Spotify Wrapped. Yes, you need Tautulli to have been running beforehand and currently for this to work.
+[Wrapperr](https://github.com/aunefyren/wrapperr) is a website-based platform and API for collecting user stats within a set timeframe using Tautulli. The data is displayed as a statistics-summary, sort of like Spotify Wrapped. Yes, you need Tautulli to have been running beforehand and currently for this to work. Note: Wrapperr is not behind authelia.
 
 | Details     |             |             |             |
 |-------------|-------------|-------------|-------------|
-
-- [:material-home: Wrapperr](https://github.com/aunefyren/wrapperr){: .header-icons } | [:octicons-link-16: Docs](https://github.com/aunefyren/wrapperr){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/aunefyren/wrapperr){: .header-icons } | [:material-docker: Docker:](https://hub.docker.com/r/aunefyren/wrapperr){: .header-icons } |
+| [:material-home: Project Home](https://github.com/aunefyren/wrapperr){: .header-icons } | [:octicons-link-16: Docs](https://github.com/aunefyren/wrapperr){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/aunefyren/wrapperr){: .header-icons } | [:material-docker: Docker:](https://hub.docker.com/r/aunefyren/wrapperr){: .header-icons }|
 
 ### 1. Installation
 


### PR DESCRIPTION
Clarified project links and added a note about Wrapperr not requiring authentication through Authelia in the documentation. Also fixed the markdown table formatting which was broken on the website.