### PR TITLE
Removing Trash Guides reference as it no longer exists

### DIFF
--- a/docs/sandbox/apps/notifiarr.md
+++ b/docs/sandbox/apps/notifiarr.md
@@ -43,8 +43,6 @@ Refer to the [Notifiarr documentation](https://notifiarr.wiki/) for more informa
 
 The role will attempt to configure sonarr, radarr, plex, and tautulli. Other apps can be edited in the config file which can be found at `"/opt/notifiarr/notifiarr.conf"` in a standard install. From time to time new options will be added and an [example config file can be found here.](https://github.com/Notifiarr/notifiarr/blob/main/examples/notifiarr.conf.example)
 
-A quickstart guide can be found on the [Trash Guides website.](https://trash-guides.info/Notifiarr/Quick-Start/)
-
 ## Advanced
 
 ### Snapshot Feature Support

--- a/docs/sandbox/apps/notifiarr.md
+++ b/docs/sandbox/apps/notifiarr.md
@@ -10,7 +10,7 @@
 
 ### 1. Setup
 
-You will need a notifiar account api key to use notifiarr. You can get one by [signing up for a free account.](https://notifiarr.com/guest/register){: .header-icons }
+You will need a Notifiarr account api key to use Notifiarr. You can get one by [signing up for a free account.](https://notifiarr.com/guest/register){: .header-icons }
 
 After logging in, you should be redirected to your profile screen.
 
@@ -18,7 +18,6 @@ After logging in, you should be redirected to your profile screen.
 - Select your Country
 - Select your Timezone
 - Change your Time Format to your liking
-- Select your Site Theme
 - Select your Notification Language
 - **Don't forget to Save your changes**
 
@@ -41,7 +40,9 @@ sb install sandbox-notifiarr
 Now go to the Notifiarr website and configure your integrations and discord server.
 Refer to the [Notifiarr documentation](https://notifiarr.wiki/) for more information.
 
-The role will attempt to configure sonarr, radarr, plex, and tautulli. Other apps can be edited in the config file which can be found at `"/opt/notifiarr/notifiarr.conf"` in a standard install. From time to time new options will be added and an [example config file can be found here.](https://github.com/Notifiarr/notifiarr/blob/main/examples/notifiarr.conf.example)
+The role will attempt to configure Sonarr, Radarr, Plex, and Tautulli. Other apps can be edited in the config file which can be found at `"/opt/notifiarr/notifiarr.conf"` in a standard install. From time to time new options will be added and an [example config file can be found here.](https://github.com/Notifiarr/notifiarr/blob/main/examples/notifiarr.conf.example)
+
+A guide to setup and sync TRaSH guides with Radarr and Sonarr can be found on the [TRaSH Guides website](https://trash-guides.info/Guide-Sync/).
 
 ## Advanced
 


### PR DESCRIPTION
Removing Trash Guides reference that no longer exists. It was removed from Trash Guides back in 2022.

For new Sandbox app/role documentation, please confirm you have completed the following tasks:

- [] App documentation page created
- [] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [] Reference added in `docs/sandbox/index.md`
- [] Reference added in `mkdocs.yml` nav menu