### PR TITLE
Add Dockwatch to sandbox docs 

### DIFF
--- a/docs/sandbox/apps/dockwatch.md
+++ b/docs/sandbox/apps/dockwatch.md
@@ -1,0 +1,44 @@
+# Dockwatch
+
+## What is it?
+
+[Dockwatch](https://github.com/Notifiarr/dockwatch) is a simple UI driven way to manage updates & notifications for Docker containers.
+
+- Link and control multiple servers
+- Automatically locate and match container icons for non Unraid usage # (1)!
+- Update schedules for container image tags by a container basis
+- Notifications by a container basis
+- Automatically try to restart unhealthy containers
+- Mass prune orphan images, volumes & networks
+- Mass actions for containers [(re-)start/stop, pull, update] # (2)!
+- Group containers in a table view for easier management
+
+1. If icon is available at [Notifiarr/images](https://github.com/Notifiarr/images).
+2. Also includes generating a `docker run` command, `docker-compose.yml` and comparing mounts.
+
+!!! warning
+    By default, the role is protected behind your Authelia/SSO middleware.
+
+| Details     |             |             |
+|-------------|-------------|-------------|
+| [:material-home: Project home](https://github.com/Notifiarr/dockwatch){: .header-icons } | [:octicons-link-16: Docs](https://github.com/Notifiarr/dockwatch#environment-variables){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/Notifiarr/dockwatch){: .header-icons }|
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-dockwatch
+
+```
+
+### 2. URL
+
+- To access dockwatch, visit `https://dockwatch._yourdomain.com_`
+
+### 3. Setup
+
+Set up the update options first, if you want to set them all at the same time use the `updates` or `frequency` button in the top right corner.
+
+Add your notifiarr API key in the notification tab in order to set up notifications.
+
+- [:octicons-link-16: Documentation: Dockwatch Docs](https://github.com/Notifiarr/dockwatch#environment-variables){: .header-icons }

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -32,6 +32,7 @@ tags:
 - **[deemix](../sandbox/apps/deemix.md)**  - tag - `sandbox-deemix`
 - **[delugevpn](../sandbox/apps/delugevpn.md)**  - tag - `sandbox-delugevpn`
 - **[discoflix](../sandbox/apps/discoflix.md)**  - tag - `sandbox-discoflix`
+- **[dockwatch](../sandbox/apps/dockwatch.md)**  - tag - `sandbox-dockwatch`
 - **[doplarr](../sandbox/apps/doplarr.md)**  - tag - `sandbox-doplarr`
 - **[duplicati](../sandbox/apps/duplicati.md)**  - tag - `sandbox-duplicati`
 - **[embystat](../sandbox/apps/embystat.md)**  - tag - `sandbox-embystat`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,6 +301,7 @@ nav:
             - Adminer: sandbox/apps/adminer.md
             - PGAdmin: sandbox/apps/pgadmin.md
           - Docker:
+            - Dockwatch: sandbox/apps/dockwatch.md
             - Ouroboros: sandbox/apps/ouroboros.md
             - Watchtower: sandbox/apps/watchtower.md
           - Flaresolverr: sandbox/apps/flaresolverr.md
@@ -499,4 +500,3 @@ nav:
           - Using Local Storage: reference/local-storage.md
           - Mounting disks: reference/guides/mount.md
           - HW transcoding on OVH: reference/OVH.md
-


### PR DESCRIPTION
This pull request adds the Dockwatch app to the sandbox apps list in the index.md and mkdocs.yml files. Dockwatch is a simple UI-driven way to manage updates and notifications for Docker containers. It allows users to link and control multiple servers, update schedules for container image tags, receive notifications, automatically restart unhealthy containers, and perform mass actions for containers. The pull request also includes the necessary installation instructions and setup details for using Dockwatch.