### PR TITLE
Fix grammar in Dockwatch docs

### DIFF
--- a/docs/sandbox/apps/dockwatch.md
+++ b/docs/sandbox/apps/dockwatch.md
@@ -16,7 +16,7 @@
 !!! warning
     By default, the role is protected behind your Authelia/SSO middleware.
 
-    By default, Dockwatch is likely unable to take action on containers do the security posture of the Docker socket proxy. You can override this behavior to allow Dockwatch to take actions by adding `dockwatch_post_enable: true` to your [inventory](../../saltbox/inventory/index.md) entries:
+    Dockwatch is likely unable to take action on containers due to the security posture of the Docker socket proxy. You can override this behavior to allow Dockwatch to take actions by adding `dockwatch_post_enable: true` to your [inventory](../../saltbox/inventory/index.md) entries.
 
 | Details     |             |             |
 |-------------|-------------|-------------|


### PR DESCRIPTION
Corrected a grammar mistake in the warning admonition of the Dockwatch documentation. This PR ensures that the sentence is grammatically correct and improves the overall clarity of the documentation.