### PR TITLE
update requestrr repo links to point to the new repo

### DIFF
--- a/docs/sandbox/apps/requestrr.md
+++ b/docs/sandbox/apps/requestrr.md
@@ -2,11 +2,11 @@
 
 ## What is it?
 
-[Requestrr](https://github.com/darkalfx/requestrr) is a chatbot used to simplify using services like Sonarr/Radarr/Ombi via the use of chat. Current platform is Discord only, but the bot was built around the ideology of quick adaptation for new features as well as new platforms.
+[Requestrr](https://github.com/thomst08/requestrr) is a chatbot used to simplify using services like Sonarr/Radarr/Ombi via the use of chat. Current platform is Discord only, but the bot was built around the ideology of quick adaptation for new features as well as new platforms.
 
 | Details     |             |             |             |
 |-------------|-------------|-------------|-------------|
-| [:material-home: Project home](https://github.com/darkalfx/requestrr){: .header-icons } | [:octicons-link-16: Docs](https://github.com/darkalfx/requestrr/wiki){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/darkalfx/requestrr){: .header-icons } | [:material-docker: Docker](https://hub.docker.com/r/hotio/requestrr){: .header-icons }|
+| [:material-home: Project home](https://github.com/thomst08/requestrr){: .header-icons } | [:octicons-link-16: Docs](https://github.com/thomst08/requestrr/wiki){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/thomst08/requestrr){: .header-icons } | [:material-docker: Docker](https://hub.docker.com/r/thomst08/requestrr){: .header-icons }|
 
 ### 1. Installation
 
@@ -22,4 +22,4 @@ sb install sandbox-requestrr
 
 ### 3. Setup
 
-- [:octicons-link-16: Documentation: Requestrr Docs](https://github.com/darkalfx/requestrr/wiki){: .header-icons }
+- [:octicons-link-16: Documentation: Requestrr Docs](https://github.com/thomst08/requestrr/wiki){: .header-icons }


### PR DESCRIPTION
The original Requestrr maintainer stopped development, archived the repo, and is redirecting everyone to a new repo by another maintainer. This updates the docs to point to that new repo.
