### PR TITLE
Add "specify version" tag to inventory docs

### DIFF
--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -9,6 +9,7 @@ tags:
   - domain
   - pin version
   - version tag
+  - specify version
 ---
 
 # Inventory


### PR DESCRIPTION
Add "specify version" tag to the inventory docs since that's what I searched for while looking for how to specific an app version to install.