### PR TITLE
Update qbit-manage.md to correct instances of qbit_manage to qbit-manage

### DIFF
--- a/docs/sandbox/apps/qbit-manage.md
+++ b/docs/sandbox/apps/qbit-manage.md
@@ -8,7 +8,7 @@
 |-------------|-------------|-------------|-------------|
 | [:material-home: qBit Manage](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:octicons-link-16: Docs](https://github.com/StuffAnThings/qbit_manage/wiki){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:material-docker: Docker:](https://hotio.dev/containers/qbitmanage/){: .header-icons } |
 
-**Functions include:-** <br />
+**Functions include:** <br />
 
 - Tag torrents based on tracker and then set seed goals/limit upload speed by tag.
 

--- a/docs/sandbox/apps/qbit-manage.md
+++ b/docs/sandbox/apps/qbit-manage.md
@@ -41,10 +41,10 @@ sb install sandbox-qbit-manage
 
 ```
 
-After installation has finished, stop the qbit_manage docker container and edit the config file that will have been created at `/opt/qbit_manage/config.yml`
+After installation has finished, stop the qbit-manage docker container and edit the config file that will have been created at `/opt/qbit-manage/config.yml`
 
 ```shell
-docker stop qbit_manage
+docker stop qbit-manage
 ```
 
 Minimally you will need to change the following items in order to connect with your qBittorrent instance:-
@@ -68,10 +68,10 @@ The config file is full of examples that more than likely will not work for you,
 After making adjustments to the config file, you can start the docker container again.
 
 ```shell
-docker start qbit_manage
+docker start qbit-manage
 ```
 
-Either tail the log ( `tail -f "/opt/qbit_manage/activity.log"` ) or open the log file after a few minutes to check for any errors or behaviour that may have been unexpected. The container has been deliberately set to **DRY RUN MODE** initially so you can see what the script will do without actually moving deleting, tagging, or categorising anything.. Once you are happy your life's work will not be destroyed and any errors have been resolved you can edit the qbit_manage variables in the sandbox settings.yml file and then run the role again. Set `qbt_dry_run: false` to run in live mode. This will delete and move files according to your settings.
+Either tail the log ( `tail -f "/opt/qbit-manage/activity.log"` ) or open the log file after a few minutes to check for any errors or behaviour that may have been unexpected. The container has been deliberately set to **DRY RUN MODE** initially so you can see what the script will do without actually moving deleting, tagging, or categorising anything.. Once you are happy your life's work will not be destroyed and any errors have been resolved you can edit the qbit_manage variables in the sandbox settings.yml file and then run the role again. Set `qbt_dry_run: false` to run in live mode. This will delete and move files according to your settings.
 
 Apply the changes to the sandbox settings file with:
 

--- a/docs/sandbox/apps/qbit-manage.md
+++ b/docs/sandbox/apps/qbit-manage.md
@@ -71,7 +71,7 @@ After making adjustments to the config file, you can start the docker container 
 docker start qbit-manage
 ```
 
-Either tail the log ( `tail -f "/opt/qbit-manage/activity.log"` ) or open the log file after a few minutes to check for any errors or behaviour that may have been unexpected. The container has been deliberately set to **DRY RUN MODE** initially so you can see what the script will do without actually moving deleting, tagging, or categorising anything.. Once you are happy your life's work will not be destroyed and any errors have been resolved you can edit the qbit_manage variables in the sandbox settings.yml file and then run the role again. Set `qbt_dry_run: false` to run in live mode. This will delete and move files according to your settings.
+Either tail the log ( `tail -f "/opt/qbit-manage/logs/activity.log"` ) or open the log file after a few minutes to check for any errors or behaviour that may have been unexpected. The container has been deliberately set to **DRY RUN MODE** initially so you can see what the script will do without actually moving deleting, tagging, or categorising anything.. Once you are happy your life's work will not be destroyed and any errors have been resolved you can edit the qbit_manage variables in the sandbox settings.yml file and then run the role again. Set `qbt_dry_run: false` to run in live mode. This will delete and move files according to your settings.
 
 Apply the changes to the sandbox settings file with:
 

--- a/docs/sandbox/apps/qbit-manage.md
+++ b/docs/sandbox/apps/qbit-manage.md
@@ -1,12 +1,12 @@
-# qBit Management
+# qBit Manage
 
 ## What is it?
 
-[qBit Management](https://github.com/StuffAnThings/qbit_manage) is a program used to manage your qBittorrent instance.
+[qBit Manage](https://github.com/StuffAnThings/qbit_manage) is a program used to manage your qBittorrent instance.
 
 | Details     |             |             |             |
 |-------------|-------------|-------------|-------------|
-| [:material-home: qBit Management](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:octicons-link-16: Docs](https://github.com/StuffAnThings/qbit_manage/wiki){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:material-docker: Docker:](https://hotio.dev/containers/qbitmanage/){: .header-icons } |
+| [:material-home: qBit Manage](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:octicons-link-16: Docs](https://github.com/StuffAnThings/qbit_manage/wiki){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/StuffAnThings/qbit_manage){: .header-icons } | [:material-docker: Docker:](https://hotio.dev/containers/qbitmanage/){: .header-icons } |
 
 **Functions include:-** <br />
 
@@ -33,7 +33,7 @@
 
 ### 1. Installation
 
-Before installing qBit Management, you should have a **[qBittorrent](../../apps/qbittorrent.md)** instance running on your local machine.
+Before installing qBit Manage, you should have a **[qBittorrent](../../apps/qbittorrent.md)** instance running on your local machine.
 
 ``` shell
 
@@ -105,4 +105,4 @@ qbit_manage:
   qbt_width: "100" # Default is "100"
 ```
 
-- [:octicons-link-16: Documentation: qBit Management Docs](https://github.com/StuffAnThings/qbit_manage/wiki){: .header-icons }
+- [:octicons-link-16: Documentation: qBit Manage Docs](https://github.com/StuffAnThings/qbit_manage/wiki){: .header-icons }


### PR DESCRIPTION
Several commands and the docker container name use a hyphen/dash rather than an underscore as the separator between qbit and manage. Updated instances where this caused an issue while following the documentation.

Please describe the purpose of this Pull Request.

Update erroneous instances where commands, container name, and paths use qbit_manage rather than what is actually created by the role, qbit-manage. Also found an issue with the logs directory missing from the tail command.

For new Sandbox app/role documentation, please confirm you have completed the following tasks:

- [] App documentation page created
- [] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [] Reference added in `docs/sandbox/index.md`
- [] Reference added in `mkdocs.yml` nav menu
