### PR TITLE
Add correct service name for cloudplow

### DIFF
--- a/docs/apps/cloudplow.md
+++ b/docs/apps/cloudplow.md
@@ -46,7 +46,7 @@ See [Example Cloudplow configs](../reference/cloudplow.md).
 /opt/cloudplow/config.json
 ```
 
-Note: Config changes require a restart: `sudo systemctl restart cloudplow`.
+Note: Config changes require a restart: `sudo systemctl restart saltbox_managed_cloudplow.service`.
 
 ### Editing
 
@@ -189,7 +189,7 @@ If you used the saltbox scripted rclone setup, there is a script that will make 
 Restart Cloudplow to apply the changes to the config.
 
 ```bash
-sudo systemctl restart cloudplow
+sudo systemctl restart saltbox_managed_cloudplow.service
 ```
 
 ## Logs and status


### PR DESCRIPTION
I was attempting to check the cloudplow service and noticed in the role the service name changed, figured updating it here would be helpful to other users.

Please describe the purpose of this Pull Request.

For new Sandbox app/role documentation, please confirm you have completed the following tasks:

- [] App documentation page created
- [] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [] Reference added in `docs/sandbox/index.md`
- [] Reference added in `mkdocs.yml` nav menu
