### PR TITLE
Add hoarder/chrome/meilisearch doc pages

### DIFF
--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -1,0 +1,34 @@
+# Chrome
+
+Headless container running Google Chrome. Useful for testing, filling out forms, web crawling, getting webpage screenshots, etc.
+
+This was created for use with Hoarder which calls for a specific version (123)
+
+<div class="grid" style="grid-template-columns: repeat(auto-fit,minmax(10.5rem,1fr));" markdown>
+
+[:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
+
+[:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
+
+</div>
+
+This role is not exposed by default.
+
+## Deployment
+
+```shell
+sb install sandbox-chrome
+```
+
+## Usage
+
+The docker commands are set to the following by default. Port 9222 is open to the container by default.
+
+```yml
+  - --no-sandbox
+  - --disable-gpu
+  - --disable-dev-shm-usage
+  - --remote-debugging-address=0.0.0.0
+  - --remote-debugging-port=9222
+  - --hide-scrollbars
+```

--- a/docs/sandbox/apps/hoarder.md
+++ b/docs/sandbox/apps/hoarder.md
@@ -1,0 +1,40 @@
+# Hoarder
+
+[Hoarder](https://hoarder.app/) is an open source "Bookmark Everything" app that uses AI for automatically tagging the content you throw at it. The app is built with self-hosting as a first class citizen.
+
+The GUI of the application is accessed through a modern web browser (no installation or configuration needed on the client side) or via any VNC client.
+
+<div class="grid" style="grid-template-columns: repeat(auto-fit,minmax(10.5rem,1fr));" markdown>
+
+[:material-bookshelf: Project Docs](https://docs.hoarder.app/){ .md-button .md-button--stretch }
+
+[:material-git: GitHub Repo](https://github.com/hoarder-app/hoarder){ .md-button .md-button--stretch }
+
+</div>
+
+## Configuration
+
+Use the ```sb inventory``` system to set any environment variables that are desired such as OpenAI API keys, downloading videos, document size limits, etc
+
+See [Hoarder Configuration](https://docs.hoarder.app/configuration) for supported variables
+
+Two keys need to be generated and stored in your ```/opt/sandbox/settings.yaml``` generate both with ```openssl rand -base64 36```
+
+Store them in the following
+
+```yml
+hoarder:
+  nextauth_secret: $$$
+meilisearch:
+  meili_master_key: $$$
+```
+
+## Deployment
+
+``` shell
+sb install sandbox-hoarder
+```
+
+## Usage
+
+Visit `https://hoarder.app/`.

--- a/docs/sandbox/apps/meilisearch.md
+++ b/docs/sandbox/apps/meilisearch.md
@@ -1,0 +1,42 @@
+# Hoarder
+
+[Meilisearch](https://www.meilisearch.com/) Meilisearch is an AI powered search tool.
+
+<div class="grid" style="grid-template-columns: repeat(auto-fit,minmax(10.5rem,1fr));" markdown>
+
+[:material-bookshelf: Project Home](https://www.meilisearch.com/){ .md-button .md-button--stretch }
+
+[:material-git: GitHub Repo](https://github.com/meilisearch/meilisearch){ .md-button .md-button--stretch }
+
+</div>
+
+This role is not externally exposed by default.
+
+## Configuration
+
+Use the ```sb inventory``` system to set any environment variables that are desired.
+
+See [Meilisearch Environment Variables](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#environment) for supported variables
+
+If not following the Hoarder role instructions:
+
+One key needs to be generated and stored in your ```/opt/sandbox/settings.yaml``` generate with ```openssl rand -base64 36```
+
+Store in the following
+
+```yml
+meilisearch:
+  meili_master_key: $$$
+```
+
+## Deployment
+
+``` shell
+sb install sandbox-meilisearch
+```
+
+## Usage
+
+Port 7700 is open to the container by default. Also analytics are disabled by default.
+
+Visit `https://www.meilisearch.com/docs`.

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -27,6 +27,7 @@ tags:
 - **[calibre-web](../sandbox/apps/calibre-web.md)**  - tag - `sandbox-calibre-web`
 - **[changedetection](../sandbox/apps/changedetection.md)**  - tag - `sandbox-changedetection`
 - **[cherry](../sandbox/apps/cherry.md)**  - tag - `sandbox-cherry`
+- **[chrome](../sandbox/apps/chrome.md)**  - tag - `sandbox-chrome`
 - **[code-server](../sandbox/apps/code-server.md)**  - tag - `sandbox-code-server`
 - **[comicstreamer](../sandbox/apps/comicstreamer.md)**  - tag - `sandbox-comicstreamer`
 - **[comixed](../sandbox/apps/comixed.md)**  - tag - `sandbox-comixed`
@@ -59,6 +60,7 @@ tags:
 - **[handbrake](../sandbox/apps/handbrake.md)**  - tag - `sandbox-handbrake`
 - **[healthchecks](../sandbox/apps/healthchecks.md)**  - tag - `sandbox-healthchecks`
 - **[heimdall](../sandbox/apps/heimdall.md)**  - tag - `sandbox-heimdall`
+- **[hoarder](../sandbox/apps/hoarder.md)**  - tag - `sandbox-hoarder`
 - **[Homarr](../sandbox/apps/homarr.md)**  - tag - `sandbox-homarr`
 - **[homeassistant](../sandbox/apps/homeassistant.md)** - tag - `sandbox-homeassistant`
 - **[homebox](../sandbox/apps/homebox.md)**  - tag - `sandbox-homebox`
@@ -83,6 +85,7 @@ tags:
 - **[mcrouter](../sandbox/apps/mcrouter.md)**  - tag - `sandbox-mcrouter`
 - **[medusa](../sandbox/apps/medusa.md)**  - tag - `sandbox-medusa`
 - **[membarr](../sandbox/apps/membarr.md)**  - tag - `sandbox-membarr`
+- **[meilisearch](../sandbox/apps/meilisearch.md)**  - tag - `sandbox-meilisearch`
 - **[minecraft](../sandbox/apps/minecraft.md)**  - tag - `sandbox-minecraft`
 - **[minecraft-bedrock](../sandbox/apps/minecraft-bedrock.md)**  - tag - `sandbox-minecraft-bedrock`
 - **[miniflux](../sandbox/apps/miniflux.md)**  - tag - `sandbox-miniflux`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
           - Actual Budget: sandbox/apps/actualbudget.md
           - AdGuard Home: sandbox/apps/adguardhome.md
           - Cherry: sandbox/apps/cherry.md
+          - Chrome: sandbox/apps/chrome.md
           - Firefox: sandbox/apps/firefox.md
           - Homebox: sandbox/apps/homebox.md
           - Immich: sandbox/apps/immich.md
@@ -203,6 +204,7 @@ nav:
           - AirDC++: sandbox/apps/airdcpp.md
           - Alltube: sandbox/apps/alltube.md
           - Archivebox: sandbox/apps/archivebox.md
+          - Hoarder: sandbox/apps/hoarder.md
           - Jdownloader2: sandbox/apps/jdownloader2.md
           - Medusa: sandbox/apps/medusa.md
           - PyLoad: sandbox/apps/pyload.md
@@ -336,6 +338,7 @@ nav:
             - Wireguard: sandbox/apps/wireguard.md
           - MakeMKV: sandbox/apps/makemkv.md
           - Maintainerr: sandbox/apps/maintainerr.md
+          - Meilisearch: sandbox/apps/meilisearch.md
           - Puddletag: sandbox/apps/puddletag.md
           - Sabthrottle: sandbox/apps/sabthrottle.md
           - Sarotate: sandbox/apps/sarotate.md


### PR DESCRIPTION
Adding new doc pages for [Sandbox PR 410](https://github.com/saltyorg/Sandbox/pull/410)

- [X] App documentation page created
- [X] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [X] Reference added in `docs/sandbox/index.md`
- [X] Reference added in `mkdocs.yml` nav menu
