### PR TITLE
add maybe-finance docs

### DIFF
--- a/docs/sandbox/apps/maybe-finance.md
+++ b/docs/sandbox/apps/maybe-finance.md
@@ -1,0 +1,26 @@
+# Maybe Finance
+
+## What is it?
+
+[Maybe Finance](https://maybefinance.com/) is an open-source OS for your personal finances
+
+| Details     |             |             |             |
+|-------------|-------------|-------------|-------------|
+| [:material-home: Project home](https://maybefinance.com/){: .header-icons } | [:octicons-link-16: Docs](https://github.com/maybe-finance/maybe/blob/main/README.md){: .header-icons } | [:octicons-mark-github-16: Github](https://github.com/maybe-finance/maybe){: .header-icons } | [:material-docker: Docker](https://ghcr.io/maybe-finance/maybe){: .header-icons }|
+
+### 1. Installation
+
+``` shell
+
+sb install sandbox-maybe-finance
+
+```
+
+### 2. URL
+
+- To access Maybe Finance, visit `https://maybe-finance._yourdomain.com_`
+
+### 3. Setup
+
+- Create an account if you do not already have one
+- Add a [Synth](https://synthfinance.com/) api key in the setting UI if you need multi-currency support

--- a/docs/sandbox/index.md
+++ b/docs/sandbox/index.md
@@ -89,6 +89,7 @@ tags:
 - **[lunasea](../sandbox/apps/lunasea.md)**  - tag - `sandbox-lunasea`
 - **[makemkv](../sandbox/apps/makemkv.md)**  - tag - `sandbox-makemkv`
 - **[maintainerr](../sandbox/apps/maintainerr.md)**  - tag - `sandbox-maintainerr`
+- **[maybe-finance](../sandbox/apps/maybe-finance.md)**  - tag - `sandbox-maybe-finance`
 - **[mcrouter](../sandbox/apps/mcrouter.md)**  - tag - `sandbox-mcrouter`
 - **[medusa](../sandbox/apps/medusa.md)**  - tag - `sandbox-medusa`
 - **[membarr](../sandbox/apps/membarr.md)**  - tag - `sandbox-membarr`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
         - Finance:
           - Firefly III: sandbox/apps/fireflyiii.md
           - Firefly III Importer: sandbox/apps/fireflyiii_importer.md
+          - Maybe Finance: sandbox/apps/maybe-finance.md
         - Landing Pages:
           - Dashy: sandbox/apps/dashy.md
           - VNStat: sandbox/apps/vnstat.md


### PR DESCRIPTION
Adding docs for Maybe Finance

Related role PR: https://github.com/saltyorg/Sandbox/pull/422

- [x] App documentation page created
- [x] markdownlint reports no errors on edited page(s) - use <https://dlaa.me/markdownlint/> if your IDE does not have this built in
- [x] Reference added in `docs/sandbox/index.md`
- [x] Reference added in `mkdocs.yml` nav menu
