### PR TITLE
Refactor: Convert inline HTML to Markdown

### DIFF
--- a/docs/faq/Plex.md
+++ b/docs/faq/Plex.md
@@ -30,15 +30,11 @@ SOME COMMANDS ON THIS PAGE IRREVOCABLY DELETE DATA
         !!! warning
             **THIS IS DESTRUCTIVE AND WILL DELETE ALL PLEX LIBRARIES AND DATA.  THERE IS NO UNDO.**
     
-        <details>
-        <summary>I understand the risk!  Show me!</summary>
-        <br />
+        ??? danger "I understand the risk!  Show me!"
 
-        ```shell
-        sudo rm -rf /opt/plex
-        ```
-
-        </details>
+            ```shell
+            sudo rm -rf /opt/plex
+            ```
 
     - Reinstall the Plex container:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,14 @@ hide:
 
 ## Created with the help of
 
+<div style="max-width: 800px" class="grid cards" markdown>
+
 - :simple-ansible: [**Ansible**](https://www.ansible.com/){target=_blank}
 - :simple-docker: [**Docker**](https://www.docker.com/){target=_blank}
 - :material-bash: [**Bash**](https://www.gnu.org/software/bash/){target=_blank}
 - :simple-python: [**Python**](https://www.python.org/){target=_blank}
+
+</div>
 
 ### What is it?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,10 @@ hide:
 
 ## Created with the help of
 
-<div style="max-width: 800px" class="grid cards" markdown>
-
-- :simple-ansible: [__Ansible__](https://www.ansible.com/){target=_blank}
-- :simple-docker: [__Docker__](https://www.docker.com/){target=_blank}
-- :material-bash: [__Bash__](https://www.gnu.org/software/bash/){target=_blank}
-- :simple-python: [__Python__](https://www.python.org/){target=_blank}
-
-</div>
+- :simple-ansible: [**Ansible**](https://www.ansible.com/){target=_blank}
+- :simple-docker: [**Docker**](https://www.docker.com/){target=_blank}
+- :material-bash: [**Bash**](https://www.gnu.org/software/bash/){target=_blank}
+- :simple-python: [**Python**](https://www.python.org/){target=_blank}
 
 ### What is it?
 

--- a/docs/saltbox/install/install.md
+++ b/docs/saltbox/install/install.md
@@ -65,9 +65,7 @@ However, it is safe to run any saltbox tag[s] [including the install tags] at wi
 
     ```
 
-<details>
-<summary>What will I see in the terminal?</summary>
-<br />
+??? info "What will I see in the terminal?"
 
 Something like this:
 
@@ -78,7 +76,6 @@ x86_64 is currently supported.
 Installing Saltbox Dependencies.
 /srv/git/saltbox$
 ```
-</details>
 
 !!! info
     See [here](../../reference/dependencies.md) for more information about the dependencies.

--- a/docs/saltbox/install/install.md
+++ b/docs/saltbox/install/install.md
@@ -67,15 +67,15 @@ However, it is safe to run any saltbox tag[s] [including the install tags] at wi
 
 ??? info "What will I see in the terminal?"
 
-Something like this:
+    Something like this:
 
-```
-~$ curl -sL https://install.saltbox.dev | sudo -H bash && cd /srv/git/saltbox
-jammy is currently supported.
-x86_64 is currently supported.
-Installing Saltbox Dependencies.
-/srv/git/saltbox$
-```
+    ```
+    ~$ curl -sL https://install.saltbox.dev | sudo -H bash && cd /srv/git/saltbox
+    jammy is currently supported.
+    x86_64 is currently supported.
+    Installing Saltbox Dependencies.
+    /srv/git/saltbox$
+    ```
 
 !!! info
     See [here](../../reference/dependencies.md) for more information about the dependencies.

--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -54,11 +54,26 @@ The variables that can be used for customization within the Inventory are listed
 
 === "GitHub File View"
 
-    | Repository | Location |
-    |------------|----------|
-    | Saltbox | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/tree/master/roles/](https://github.com/saltyorg/Saltbox/tree/master/roles)**&lt;role_name&gt;/defaults/main.yml** |
-    | Sandbox | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Sandbox/tree/master/roles/](https://github.com/saltyorg/Sandbox/tree/master/roles)**&lt;role_name&gt;/defaults/main.yml** |
-    | Global | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml](https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml) |
+    <table>
+      <tr>
+        <td>Saltbox</td>
+        <td>
+          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/tree/master/roles/](https://github.com/saltyorg/Saltbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
+        </td>
+      </tr>
+      <tr>
+        <td>Sandbox</td>
+        <td>
+          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Sandbox/tree/master/roles/](https://github.com/saltyorg/Sandbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
+        </td>
+      </tr>
+      <tr>
+        <td>Global</td>
+        <td>
+          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml](https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml)
+        </td>
+      </tr>
+    </table>
 
 === "File Path on Saltbox Host"
 

--- a/docs/saltbox/inventory/index.md
+++ b/docs/saltbox/inventory/index.md
@@ -54,26 +54,11 @@ The variables that can be used for customization within the Inventory are listed
 
 === "GitHub File View"
 
-    <table>
-      <tr>
-        <td>Saltbox</td>
-        <td>
-          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/tree/master/roles/](https://github.com/saltyorg/Saltbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
-        </td>
-      </tr>
-      <tr>
-        <td>Sandbox</td>
-        <td>
-          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Sandbox/tree/master/roles/](https://github.com/saltyorg/Sandbox/tree/master/roles)<span style="color: #9397b1;">**&lt;role_name&gt;</span><span style="color: #e6695b;">/defaults/main.yml**</span>
-        </td>
-      </tr>
-      <tr>
-        <td>Global</td>
-        <td>
-          [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml](https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml)
-        </td>
-      </tr>
-    </table>
+    | Repository | Location |
+    |------------|----------|
+    | Saltbox | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/tree/master/roles/](https://github.com/saltyorg/Saltbox/tree/master/roles)**&lt;role_name&gt;/defaults/main.yml** |
+    | Sandbox | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Sandbox/tree/master/roles/](https://github.com/saltyorg/Sandbox/tree/master/roles)**&lt;role_name&gt;/defaults/main.yml** |
+    | Global | [:fontawesome-solid-folder-tree: https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml](https://github.com/saltyorg/Saltbox/blob/master/inventories/group_vars/all.yml) |
 
 === "File Path on Saltbox Host"
 
@@ -105,9 +90,8 @@ The variables that can be used for customization within the Inventory are listed
 
     For use cases involving Docker parameters beyond those exposed in the role files, it is still possible to construct usable Saltbox variables. The following resources provide the required syntax elements:
 
-    <sub><https://github.com/saltyorg/Saltbox/blob/master/resources/tasks/docker/create_docker_container.yml></sub>
-
-    <sub><https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html></sub>
+    - <https://github.com/saltyorg/Saltbox/blob/master/resources/tasks/docker/create_docker_container.yml>
+    - <https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html>
 
 === "Something Missing?"
 
@@ -137,10 +121,8 @@ sonarr_docker_image_tag: "release"
 sonarr_docker_image: "{{ lookup('vars', sonarr_name + '_docker_image_repo', default=sonarr_docker_image_repo)
                          + ':' + lookup('vars', sonarr_name + '_docker_image_tag', default=sonarr_docker_image_tag) }}"
 ```
-<div class="result" markdown>
-!!! info "\`default\` Variables"
+!!! info "`default` Variables"
     Variables suffixed with `_default` and variables predefined with non-empty values (specifically, not followed by a blank, an empty string `""`, list `[]` or dictionary `{}`) fall under this category. Using the Inventory to define one of these variables is therefore considered an override, as it will cause the value(s) originally stored in it to be discarded.
-</div>
 
 Note: `sonarr_docker_image_tag: "release"`. 
 
@@ -167,10 +149,8 @@ code_server_docker_volumes_default:
   - "{{ server_appdata_path }}:/host_opt"
 code_server_docker_volumes_custom: []
 ```
-<div class="result" markdown>
-!!! info "\`custom\` Variables"
+!!! info "`custom` Variables"
     Variables suffixed with `_custom` and variables defined with an empty string fall under this category. Respectively, this is used to add custom values to a list or a dictionary without discarding existing values, and to assign a value to an exposed role-specific setting.
-</div>
 
 Note the list syntax. Since we want the container to preserve existing volumes, the `_docker_volumes_default` list should not be overridden. Instead, we use the `_docker_volumes_custom` list.
 

--- a/docs/sandbox/apps/actualbudget.md
+++ b/docs/sandbox/apps/actualbudget.md
@@ -18,4 +18,4 @@ To access Actual Budget, visit ``https://actualbudget._yourdomain.com_``
 
 ## **3. Usage**
 
-<span style="color:#AAFF00;">[Documentation: Actual Budget Docs](https://actualbudget.org/docs/)</span>
+**[Documentation: Actual Budget Docs](https://actualbudget.org/docs/)**

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,9 +4,13 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
+<div class="grid sb-buttons" markdown data-search-exclude>
+
 [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
 
 [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
+
+</div>
 
 This role is not exposed by default.
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,10 +4,9 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
-| | |
-|---|---|
-| [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch } | [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch } |
-{ .borderless }
+[:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
+
+[:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
 
 This role is not exposed by default.
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,7 +4,7 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
-<div class="grid sb-buttons" markdown data-search-exclude>
+<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
 
 [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -5,11 +5,8 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 This was created for use with Hoarder which calls for a specific version (123)
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
-
 [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
-
 [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
-
 </div>
 
 This role is not exposed by default.

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,11 +4,11 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
-<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+<div class="grid sb-buttons" markdown data-search-exclude>
 
-[:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
+[:material-bookshelf: Github Repo&nbsp;&nbsp;](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
 
-[:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
+[:material-git: Google Artifact&nbsp;&nbsp;](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
 
 </div>
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,9 +4,9 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
-[:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
-
-[:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
+| | |
+|---|---|
+| [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch } | [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch } |
 
 This role is not exposed by default.
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -4,13 +4,9 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 
 This was created for use with Hoarder which calls for a specific version (123)
 
-<div class="grid" style="grid-template-columns: repeat(auto-fit,minmax(10.5rem,1fr));" markdown>
-
 [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
 
 [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
-
-</div>
 
 This role is not exposed by default.
 

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -5,8 +5,11 @@ Headless container running Google Chrome. Useful for testing, filling out forms,
 This was created for use with Hoarder which calls for a specific version (123)
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+
 [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch }
+
 [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch }
+
 </div>
 
 This role is not exposed by default.

--- a/docs/sandbox/apps/chrome.md
+++ b/docs/sandbox/apps/chrome.md
@@ -7,6 +7,7 @@ This was created for use with Hoarder which calls for a specific version (123)
 | | |
 |---|---|
 | [:material-bookshelf: Github Repo](https://github.com/jlandure/alpine-chrome/blob/master/Dockerfile){ .md-button .md-button--stretch } | [:material-git: Google Artifact](https://console.cloud.google.com/artifacts/docker/zenika-hub/us/gcr.io/alpine-chrome/sha256:e38563d4475a3d791e986500a2e4125c9afd13798067138881cf770b1f6f3980){ .md-button .md-button--stretch } |
+{ .borderless }
 
 This role is not exposed by default.
 

--- a/docs/sandbox/apps/firefox.md
+++ b/docs/sandbox/apps/firefox.md
@@ -52,11 +52,11 @@ sb install sandbox-firefox
 
 ## Usage
 
-### <span class="icon-indent-right"></span> Web
+### :material-web: Web
 
 Visit `https://firefox._yourdomain.com_`.
 
-### <span class="icon-indent-right"></span> VNC
+### :material-remote-desktop: VNC
 
 The role supports VNC access over an SSH tunnel (local port forwarding) to Saltbox.
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,17 +8,13 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
-<div class="grid sb-buttons" markdown data-search-exclude>
+[:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
 
-[:material-home: Homepage&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
+[:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
 
-[:material-bookshelf: Manual&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
+[:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
 
-[:octicons-container-16: Releases&nbsp;&nbsp;](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
-
-[:fontawesome-brands-github: Community&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
-
-</div>
+[:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
 
 ---
 
@@ -46,11 +42,11 @@ docker exec -it plextraktsync plextraktsync login
 
 ## Usage
 
-### <span class="icon-indent-right"></span> Daemon
+### Daemon
 
 Once configured, the selected Plex user's streaming activity is automatically scrobbled.
 
-### <span class="icon-indent-right"></span> CLI
+### CLI
 
 To perform a one-time sync of the data you have specified in the configuration file:
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,11 +8,13 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
-| | |
-|---|---|
-| [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch } |
-| [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch } | [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch } |
-{ .borderless }
+[:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
+
+[:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
+
+[:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
+
+[:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
 
 ---
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -9,15 +9,10 @@ tags:
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
-
 [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
-
 [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
-
 [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
-
 [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
-
 </div>
 
 ---

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,13 +8,10 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
-[:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
-
-[:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
-
-[:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
-
-[:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
+| | |
+|---|---|
+| [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch } |
+| [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch } | [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch } |
 
 ---
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,7 +8,7 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
-<div class="grid sb-buttons" markdown data-search-exclude>
+<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
 
 [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -12,6 +12,7 @@ Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media
 |---|---|
 | [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch } |
 | [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch } | [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch } |
+{ .borderless }
 
 ---
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,15 +8,15 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
-<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+<div class="grid sb-buttons" markdown data-search-exclude>
 
-[:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
+[:material-home: Homepage&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
 
-[:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
+[:material-bookshelf: Manual&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
 
-[:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
+[:octicons-container-16: Releases&nbsp;&nbsp;](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
 
-[:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
+[:fontawesome-brands-github: Community&nbsp;&nbsp;](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
 
 </div>
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -8,6 +8,8 @@ tags:
 
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
+<div class="grid sb-buttons" markdown data-search-exclude>
+
 [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
 
 [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
@@ -15,6 +17,8 @@ Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media
 [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
 
 [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
+
+</div>
 
 ---
 

--- a/docs/sandbox/apps/plextraktsync.md
+++ b/docs/sandbox/apps/plextraktsync.md
@@ -9,10 +9,15 @@ tags:
 Self-hosted application that adds a two-way-sync between trakt.tv and Plex Media Server. It requires a trakt.tv account but no Plex premium and no Trakt VIP subscriptions, unlike the Plex app provided by Trakt.
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+
 [:material-home: Homepage](https://github.com/Taxel/PlexTraktSync){ .md-button .md-button--stretch }
+
 [:material-bookshelf: Manual](https://github.com/Taxel/PlexTraktSync/blob/main/README.md#setup){ .md-button .md-button--stretch }
+
 [:octicons-container-16: Releases](https://github.com/taxel/PlexTraktSync/pkgs/container/plextraktsync){ .md-button .md-button--stretch }
+
 [:fontawesome-brands-github: Community](https://github.com/Taxel/PlexTraktSync/discussions){ .md-button .md-button--stretch }
+
 </div>
 
 ---

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,13 +10,10 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
-[:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
-
-[:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
-
-[:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
-
-[:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
+| | |
+|---|---|
+| [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch } |
+| [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch } | [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch } |
 
 ---
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,15 +10,15 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
-<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+<div class="grid sb-buttons" markdown data-search-exclude>
 
-[:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
+[:material-home: Homepage&nbsp;&nbsp;](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
 
-[:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
+[:material-bookshelf: Manual&nbsp;&nbsp;](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
 
-[:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
+[:octicons-container-16: Releases&nbsp;&nbsp;](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
 
-[:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
+[:fontawesome-brands-discord: Community&nbsp;&nbsp;](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
 
 </div>
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,17 +10,13 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
-<div class="grid sb-buttons" markdown data-search-exclude>
+[:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
 
-[:material-home: Homepage&nbsp;&nbsp;](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
+[:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
 
-[:material-bookshelf: Manual&nbsp;&nbsp;](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
+[:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
 
-[:octicons-container-16: Releases&nbsp;&nbsp;](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
-
-[:fontawesome-brands-discord: Community&nbsp;&nbsp;](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
-
-</div>
+[:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
 
 ---
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -11,10 +11,15 @@ tags:
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
+
 [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
+
 [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
+
 [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
+
 [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
+
 </div>
 
 ---

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,6 +10,8 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
+<div class="grid sb-buttons" markdown data-search-exclude>
+
 [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
 
 [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
@@ -17,6 +19,8 @@ This tool's primary goal is to sync your backends' play states without relying o
 [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
 
 [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
+
+</div>
 
 ---
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,11 +10,13 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
-| | |
-|---|---|
-| [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch } |
-| [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch } | [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch } |
-{ .borderless }
+[:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
+
+[:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
+
+[:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
+
+[:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
 
 ---
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -10,7 +10,7 @@ tags:
 
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
-<div class="grid sb-buttons" markdown data-search-exclude>
+<div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
 
 [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
 

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -11,15 +11,10 @@ tags:
 This tool's primary goal is to sync your backends' play states without relying on third party services. Out of the box, it supports Jellyfin, Plex and Emby media servers.
 
 <div class="grid sb-buttons" style="grid-template-columns: repeat(2, 1fr);" markdown data-search-exclude>
-
 [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch }
-
 [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch }
-
 [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch }
-
 [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch }
-
 </div>
 
 ---

--- a/docs/sandbox/apps/watchstate.md
+++ b/docs/sandbox/apps/watchstate.md
@@ -14,6 +14,7 @@ This tool's primary goal is to sync your backends' play states without relying o
 |---|---|
 | [:material-home: Homepage](https://github.com/arabcoders/watchstate){ .md-button .md-button--stretch } | [:material-bookshelf: Manual](https://github.com/ArabCoders/watchstate/blob/master/FAQ.md){ .md-button .md-button--stretch } |
 | [:octicons-container-16: Releases](https://github.com/arabcoders/watchstate/pkgs/container/watchstate){ .md-button .md-button--stretch } | [:fontawesome-brands-discord: Community](https://discord.gg/haUXHJyj6Y){ .md-button .md-button--stretch } |
+{ .borderless }
 
 ---
 


### PR DESCRIPTION
Convert inline HTML elements to proper Markdown syntax across documentation files.