### PR TITLE
build(ci): add dedicated preview config without optimize

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build mkdocs
         run: |
-          mkdocs build --clean
+          mkdocs build --clean --config-file mkdocs.preview.yml
           mkdocs --version
         env:
           CI: true

--- a/mkdocs.preview.yml
+++ b/mkdocs.preview.yml
@@ -1,0 +1,526 @@
+site_name: docs.saltbox.dev
+site_url: https://docs.saltbox.dev/
+site_author: salty
+site_description: Saltbox is an Ansible-based solution for rapidly deploying a Docker containerized cloud media server.
+
+repo_name: docs
+repo_url: https://github.com/saltyorg/docs
+
+edit_uri: edit/main/docs/
+
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
+strict: true
+
+theme:
+  name: material
+  icon:
+    logo: material/sofa
+    repo: fontawesome/brands/github-alt
+  custom_dir: overrides
+  features:
+    - content.action.edit
+    - content.action.view
+    - content.code.annotate
+    - content.code.copy
+    - content.tooltips
+    - header.autohide
+    - navigation.footer
+    - navigation.instant
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+  language: en
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
+plugins:
+  - privacy:
+      enabled: !ENV [CI, false]
+      cache: true
+      cache_dir: .cache/plugin/privacy
+      assets: true
+      assets_fetch: true
+      links_attr_map:
+        target: _blank
+      links_noopener: true
+  - search:
+      lang: en
+  - meta
+  - git-revision-date-localized
+  - minify:
+      minify_html: true
+  - git-committers:
+      enabled: !ENV [CI, false]
+      cache_dir: .cache/plugin/git-committers/
+      repository: saltyorg/docs
+      branch: main
+  - redirects:
+      redirect_maps:
+        'saltbox/upgrade/traefik3.md': 'reference/guides/deprecated/traefik3.md'
+
+extra:
+  generator: false
+  social:
+    - icon: fontawesome/solid/heart
+      class: md-social__link heart
+      link: "https://github.com/sponsors/saltydk"
+      name: Donate
+    - icon: fontawesome/brands/discord
+      class: md-social__link
+      link: "https://discord.gg/ugfKXpFND8"
+      name: Discord
+    - icon: fontawesome/brands/github
+      class: md-social__link
+      link: "https://github.com/saltyorg/Saltbox"
+      name: GitHub
+
+markdown_extensions:
+  - abbr
+  - meta
+  - pymdownx.highlight
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - attr_list
+  - footnotes
+  - md_in_html
+  - pymdownx.tilde
+  - pymdownx.snippets
+  - toc:
+      permalink: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - https://code.jquery.com/jquery-3.5.1.min.js
+
+nav:
+  - Home: index.md
+  - Saltbox:
+      - Basics: saltbox/basics/basics.md
+      - Prerequisites: saltbox/prerequisites/prerequisites.md
+      - Install Types: saltbox/basics/install-types.md
+      - Install: saltbox/install/install.md
+      - After-Install: saltbox/install/after.md
+      - Update: saltbox/basics/update.md
+      - Accessing Apps: saltbox/basics/accessing-apps.md
+      - Paths: saltbox/basics/paths.md
+      - Inventory: saltbox/inventory/index.md
+      - Backup/Restore:
+          - Settings: saltbox/backup/settings.md
+          - Backup: saltbox/backup/backup.md
+          - Restore: saltbox/backup/restore.md
+          - Migrate: saltbox/backup/migrate.md
+
+  - Sandbox:
+      - Basics: sandbox/basics.md
+      - Settings: sandbox/settings.md
+      - Index: sandbox/index.md
+      - Apps:
+        - Multiple Instances (legacy): sandbox/apps/arrx.md
+        - General:
+          - AdGuard Home: sandbox/apps/adguardhome.md
+          - Cherry: sandbox/apps/cherry.md
+          - Chrome: sandbox/apps/chrome.md
+          - Elasticsearch: sandbox/apps/elasticsearch.md
+          - Firefox: sandbox/apps/firefox.md
+          - Homebox: sandbox/apps/homebox.md
+          - Immich: sandbox/apps/immich.md
+          - Joplin: sandbox/apps/joplin.md
+          - Linkding: sandbox/apps/linkding.md
+          - Miniflux: sandbox/apps/miniflux.md
+          - n8n: sandbox/apps/n8n.md
+          - Nabarr: sandbox/apps/nabarr.md
+          - Notifiarr: sandbox/apps/notifiarr.md
+          - Photoprism: sandbox/apps/photoprism.md
+          - Profilarr: sandbox/apps/profilarr.md
+          - Recyclarr: sandbox/apps/recyclarr.md
+          - Resilio Sync: sandbox/apps/resiliosync.md
+          - The Lounge: sandbox/apps/thelounge.md
+          - Trilium Notes: sandbox/apps/trilium.md
+          - Wrapperr: sandbox/apps/wrapperr.md
+          - Yourspotify: sandbox/apps/yourspotify.md
+          - ZNC: sandbox/apps/znc.md
+        - Content Management:
+          - Mealie: sandbox/apps/mealie.md
+          - Tandoor Recipes: sandbox/apps/tandoor.md
+          - Wordpress: sandbox/apps/wordpress.md
+        - Development:
+          - Changedetection: sandbox/apps/changedetection.md
+          - Code-server: sandbox/apps/code-server.md
+          - Forgejo: sandbox/apps/forgejo.md
+          - Gitea: sandbox/apps/gitea.md
+          - Gotenberg: sandbox/apps/gotenberg.md
+          - Docker:
+            - Yacht: sandbox/apps/yacht.md
+          - Mcrouter: sandbox/apps/mcrouter.md
+          - OliveTin: sandbox/apps/olivetin.md
+          - Reposilite: sandbox/apps/reposilite.md
+          - SemaphoreUI: sandbox/apps/semaphoreui.md
+          - Tika: sandbox/apps/tika.md
+        - Downloading:
+          - AirDC++: sandbox/apps/airdcpp.md
+          - Archivebox: sandbox/apps/archivebox.md
+          - Jdownloader2: sandbox/apps/jdownloader2.md
+          - Karakeep: sandbox/apps/karakeep.md
+          - Medusa: sandbox/apps/medusa.md
+          - PyLoad: sandbox/apps/pyload.md
+          - Rdt-client: sandbox/apps/rdtclient.md
+          - Resilio Sync: sandbox/apps/resiliosync.md
+          - Tubearchivist: sandbox/apps/tubearchivist.md
+          - Tvheadend: sandbox/apps/tvheadend.md
+          - Torrents:
+            - Delugevpn: sandbox/apps/delugevpn.md
+            - LunaSea: sandbox/apps/lunasea.md
+            - QBit Management: sandbox/apps/qbit-manage.md
+            - QBittorrentVPN: sandbox/apps/qbittorrentvpn.md
+            - Rflood: sandbox/apps/rflood.md
+            - Rfloodx: sandbox/apps/rfloodx.md
+            - Tqm: sandbox/apps/tqm.md
+            - Trackarr: sandbox/apps/trackarr.md
+            - Transmission: sandbox/apps/transmission.md
+            - Transmission VPN: sandbox/apps/transmissionvpn.md
+            - Transmissionx: sandbox/apps/transmissionx.md
+        - File Management:
+          - Filebot: sandbox/apps/filebot.md
+          - Filebrowser: sandbox/apps/filebrowser.md
+          - Filezilla: sandbox/apps/filezilla.md
+          - Krusader: sandbox/apps/krusader.md
+          - Paperless-NGX: sandbox/apps/paperless-ngx.md
+          - PrivateBin: sandbox/apps/privatebin.md
+          - XBackBone: sandbox/apps/xbackbone.md
+        - Finance:
+          - Actual Budget: sandbox/apps/actualbudget.md
+          - Firefly III: sandbox/apps/fireflyiii.md
+          - Firefly III Importer: sandbox/apps/fireflyiii_importer.md
+          - Maybe Finance: sandbox/apps/maybe-finance.md
+        - Landing Pages:
+          - Dashy: sandbox/apps/dashy.md
+          - VNStat: sandbox/apps/vnstat.md
+          - Heimdall: sandbox/apps/heimdall.md
+          - Homarr: sandbox/apps/homarr.md
+          - Homepage: sandbox/apps/homepage.md
+        - Game Servers:
+          - Factorio: sandbox/apps/factorio.md
+          - Foundry: sandbox/apps/foundry.md
+          - LinuxGSM: sandbox/apps/lgsm.md
+          - MC-Router: sandbox/apps/mcrouter.md
+          - Minecraft: sandbox/apps/minecraft.md
+          - Minecraft Bedrock: sandbox/apps/minecraft-bedrock.md
+        - Media Management:
+          - Books:
+            - Audiobookshelf: sandbox/apps/audiobookshelf.md
+            - Booksonic: sandbox/apps/booksonic.md
+            - Bookstack: sandbox/apps/bookstack.md
+            - Calibre: sandbox/apps/calibre.md
+            - Calibre-web: sandbox/apps/calibre-web.md
+            - Codex: sandbox/apps/codex.md
+            - Comicstreamer: sandbox/apps/comicstreamer.md
+            - Comixed: sandbox/apps/comixed.md
+            - Kavita: sandbox/apps/kavita.md
+            - Komga: sandbox/apps/komga.md
+            - Lazylibrarian: sandbox/apps/lazylibrarian.md
+            - Mylar3: sandbox/apps/mylar3.md
+            - Wikijs: sandbox/apps/wikijs.md
+          # - Indexers:
+          - Metadata Management:
+            - Kometa: sandbox/apps/kometa.md
+            - MKVToolNix: sandbox/apps/mkvtoolnix.md
+            - Plex-Utills: sandbox/apps/plex-utills.md
+            - Python-plexlibrary: sandbox/apps/python-plexlibrary.md
+            - Unmanic: sandbox/apps/unmanic.md
+          # - Movies:
+          - Music:
+            - Airsonic: sandbox/apps/airsonic.md
+            - Beets: sandbox/apps/beets.md
+            - Deemix: sandbox/apps/deemix.md
+            - Funkwhale: sandbox/apps/funkwhale.md
+            - Navidrome: sandbox/apps/navidrome.md
+          - TV:
+            - Threadfin: sandbox/apps/threadfin.md
+            - Xteve: sandbox/apps/xteve.md
+        - Media Servers and add-ons:
+          - Embystat: sandbox/apps/embystat.md
+          - Plex:
+            - Extended Personal Media Scanner: sandbox/apps/epms.md
+            - Gaps: sandbox/apps/gaps.md
+            - Goplaxt: sandbox/apps/goplaxt.md
+            - Kitana: sandbox/apps/kitana.md
+            - Membarr: sandbox/apps/membarr.md
+            - Plex Auto Languages: sandbox/apps/plex-auto-languages.md
+            - Plex Dupefinder: sandbox/apps/plex-dupefinder.md
+            - Plex Patrol: sandbox/apps/plex-patrol.md
+            - PlexTraktSync: sandbox/apps/plextraktsync.md
+            - Plex-Utills: sandbox/apps/plex-utills.md
+            - Tauticord: sandbox/apps/tauticord.md
+            - Wrapperr: sandbox/apps/wrapperr.md
+            - Wizarr: sandbox/apps/wizarr.md
+          - Requests:
+            - DiscoFlix: sandbox/apps/discoflix.md
+            - Doplarr: sandbox/apps/doplarr.md
+            - Jellyseerr: sandbox/apps/jellyseerr.md
+            - Ombi: sandbox/apps/ombi.md
+            - Ombix: sandbox/apps/ombix.md
+            - Requestrr: sandbox/apps/requestrr.md
+            - Requestrrx: sandbox/apps/requestrrx.md
+          - Stash: sandbox/apps/stash.md
+          - WatchState: sandbox/apps/watchstate.md
+        - Nextcloud: sandbox/apps/nextcloud.md
+        - Social:
+          - Gotify: sandbox/apps/gotify.md
+          - Moviematch: sandbox/apps/moviematch.md
+          - RocketChat: sandbox/apps/rocketchat.md
+          - TeamSpeak: sandbox/apps/teamspeak.md
+        - Utilities:
+          - A-Train: sandbox/apps/a-train.md
+          - Database Management:
+            - Adminer: sandbox/apps/adminer.md
+            - PGAdmin: sandbox/apps/pgadmin.md
+            - phpmyadmin: sandbox/apps/phpmyadmin.md
+          - Docker:
+            - Dockwatch: sandbox/apps/dockwatch.md
+            - Watchtower: sandbox/apps/watchtower.md
+          - Flaresolverr: sandbox/apps/flaresolverr.md
+          - FreshRSS: sandbox/apps/freshrss.md
+          - Guacamole: sandbox/apps/guacamole.md
+          - Handbrake: sandbox/apps/handbrake.md
+          - Influxdb: sandbox/apps/influxdb.md
+          - Influxdb2: sandbox/apps/influxdb2.md
+          - Invoice Ninja: sandbox/apps/invoiceninja.md
+          - Home Automation:
+            - ESPHome: sandbox/apps/esphome.md
+            - Home Assistant: sandbox/apps/homeassistant.md
+            - MQTT: sandbox/apps/mqtt.md
+            - Node-Red: sandbox/apps/node-red.md
+          - Log Management:
+            - GoAccess: sandbox/apps/goaccess.md
+            - Logarr: sandbox/apps/logarr.md
+            - Monitorr: sandbox/apps/monitorr.md
+          - Networking:
+            - Kcptun-client: sandbox/apps/kcptun-client.md
+            - Kcptun-server: sandbox/apps/kcptun-server.md
+            - Unifi Network Application: sandbox/apps/unifi-network-application.md
+            - Wireguard: sandbox/apps/wireguard.md
+          - MakeMKV: sandbox/apps/makemkv.md
+          - Maintainerr: sandbox/apps/maintainerr.md
+          - Meilisearch: sandbox/apps/meilisearch.md
+          - Puddletag: sandbox/apps/puddletag.md
+          - Sabthrottle: sandbox/apps/sabthrottle.md
+          - Sarotate: sandbox/apps/sarotate.md
+          - Speedtest: sandbox/apps/speedtest.md
+          - Sqlitebrowser: sandbox/apps/sqlitebrowser.md
+          - Sshwifty: sandbox/apps/sshwifty.md
+          - Tdarr: sandbox/apps/tdarr.md
+          - Tdarr Node: sandbox/apps/tdarr-node.md
+          - System:
+            - Apprise: sandbox/apps/apprise.md
+            - Glances-web: sandbox/apps/glances_web.md
+            - Healthchecks: sandbox/apps/healthchecks.md
+            - Duplicati: sandbox/apps/duplicati.md
+          - SyncThing: sandbox/apps/syncthing.md
+          - Telegraf: sandbox/apps/telegraf.md
+          - Teslamate: sandbox/apps/teslamate.md
+          - Traefik-Robotstxt: sandbox/apps/traefik-robotstxt.md
+          - Uptime Kuma: sandbox/apps/uptime-kuma.md
+          - Vaultwarden: sandbox/apps/vaultwarden.md
+          - Varken: sandbox/apps/varken.md
+
+  - Apps:
+      - Saltbox standard [set up in this order]:
+        - Sabnzbd: apps/sabnzbd.md
+        - Qbittorrent: apps/qbittorrent.md
+        - Nzbhydra2: apps/nzbhydra2.md
+        - Jackett: apps/jackett.md
+        - Plex: apps/plex.md
+        - Autoscan: apps/autoscan.md
+        - Sonarr: apps/sonarr.md
+        - Radarr: apps/radarr.md
+        - Lidarr: apps/lidarr.md
+        - Tautulli: apps/tautulli.md
+        - Overseerr: apps/overseerr.md
+        - Portainer: apps/portainer.md
+      - Other Media Servers:
+          - Emby: apps/emby.md
+          - Jellyfin: apps/jellyfin.md
+      - Alternatives to Core Apps:
+        - Petio: apps/petio.md
+        - Prowlarr: apps/prowlarr.md
+        - Rutorrent: apps/rutorrent.md
+        - Deluge: apps/deluge.md
+        - Nzbget: apps/nzbget.md
+      - Others:
+        - Authelia: apps/authelia.md
+        - Authentik: apps/authentik.md
+        - Autobrr: apps/autobrr.md
+        - Cloudplow: apps/cloudplow.md
+        - Bazarr: apps/bazarr.md
+        - BTRFS Maintenance: apps/btrfsmaintenance.md
+        - Dozzle: apps/dozzle.md
+        - Gluetun: apps/gluetun.md
+        - Hetzner NFS: apps/hetzner-nfs.md
+        - Netdata: apps/netdata.md
+        - Transfer: apps/transfer.md
+        - Readarr: apps/readarr.md
+        - asshama: apps/asshama.md
+        - Unpackerr: apps/unpackerr.md
+        - Whisparr: apps/whisparr.md
+      - Support Apps:
+          - diun: apps/diun.md
+          - MariaDB: apps/mariadb.md
+          - PostgreSQL: apps/postgres.md
+      - Visualization:
+          - Grafana: apps/grafana.md
+      - TODO - NEED UPDATING:
+          - Organizr: apps/organizr.md
+      - Utility tags:
+          - Plex-DB: apps/utility_tags/plex-db.md
+
+  - FAQ:
+      - System: faq/system.md
+      - Cloud Storage: faq/cloud-storage.md
+      - CloudFlare: faq/cloudflare.md
+      - Cloudplow: faq/cloudplow.md
+      - Docker: faq/docker.md
+      - Hetzner & Google IPv6: faq/hetzner.md
+      - Install: faq/install.md
+      - Backup and Restore: faq/backup-and-restore.md
+      - Rclone: faq/rclone.md
+      - Plex: faq/plex.md
+      - ruTorrent: faq/rutorrent.md
+      - Misc: faq/misc.md
+      - sb: faq/sb.md
+      - Bazarr: faq/bazarr.md
+
+  - Advanced:
+      - Index: advanced/index.md
+      - Adding Your Own Containers: advanced/your-own-containers.md
+      - Container Healthchecks: advanced/healthchecks.md
+      - Styled Error Pages: advanced/styled-error-pages.md
+      - Tailscale: advanced/tailscale.md
+      - Themepark Styles for apps: advanced/themepark.md
+      - User crontab examples: advanced/user-crontab-examples.md
+      - Feeder Mount: advanced/feeder.md
+      - Nvidia: advanced/nvidia.md
+      - CrowdSec: advanced/crowdsec.md
+
+  - Reference:
+      - Guides:
+        - General:
+          - Chazlarson Guides:
+              - Can I run Saltbox on this server?: reference/guides/chazguides/server.md
+              - Did my Saltbox install succeed?: reference/guides/chazguides/success.md
+              - How do I mount a cloud drive?: reference/guides/chazguides/teamdrive.md
+              - I can't see my media!: reference/guides/chazguides/no-media.md
+              - Why is my disk full?: reference/guides/chazguides/disk-full.md
+              - Installing Saltbox on a home server: reference/guides/chazguides/home-server.md
+              - Obsolete and deprecated:
+                - Tip 44 Guide to Shared Drive/Service Account setup for Saltbox: reference/guides/chazguides/tip44.md
+                - Plex Autoscan Mappings; how do they work?: reference/guides/chazguides/pas-map.md
+        - Linux:
+          - Aliases: reference/guides/aliases.md
+          - code-server for easier file editing: reference/guides/code-server-setup.md
+        - Plex:
+          - Tautulii Custom Scripts: reference/guides/tautuliscripts.md
+        - Downloading:
+          - Hardlinking: reference/guides/hardlinking.md
+        - Google:
+          - Creating a Shared Drive: reference/guides/google-shared-drive.md
+        - Dropbox:
+          - General Dropbox Topics: reference/guides/dropbox-general.md
+        - Rclone:
+          - Creating an Rclone remote: reference/guides/rclone-remote-generic.md
+          - Creating a Dropbox remote: reference/guides/rclone-remote-dropbox.md
+          - Creating a Google remote: reference/guides/rclone-remote.md
+          - Creating a Crypt remote: reference/guides/rclone-remote-encrypted.md
+        - Migration:
+          - Cloudbox: reference/guides/cloudbox.md
+          - Cloud A to Cloud B: reference/guides/cloudtocloud.md
+        - Further Reading and Links:
+          - Suggested Reading: reference/guides/suggested_reading.md
+          - Links: reference/guides/links.md
+          - Other: reference/guides/other.md
+
+      - Topics:
+        - Prerequisite References:
+          - Server: reference/server.md
+          - Domain Name: reference/domain.md
+          - Cloud Storage: reference/cloud.md
+          - Plex Account: reference/plex.md
+          - Media Sources: reference/usenet-torrent.md
+        - Install References:
+          - Dependencies: reference/dependencies.md
+          - Accounts and Settings: reference/accounts.md
+          - Preinstall: reference/preinstall.md
+          - Rclone: reference/rclone.md
+          # - Rclone [Auto]: reference/rclone-auto.md
+          - Rclone [Manual]: reference/rclone-manual.md
+          - Install: reference/install.md
+        - Google References:
+          - Google Permissions: reference/google-account-perms.md
+          - Google Project: reference/google-project-setup.md
+          - Google Group: reference/google-group-setup.md
+          - Google SDK: reference/google-gcloud-tools-install.md
+          - Google Service Accounts: reference/google-service-accounts.md
+          - Google Shared Drives: reference/google-shared-drives.md
+        - Application References:
+          - Removing apps: reference/guides/app-remove.md
+          - Resetting apps: reference/guides/app-reset.md
+          - Updating apps: reference/guides/app-update.md
+        - Other References:
+          - Autoscan rewrites: reference/guides/autoscan-rewrites.md
+          - Saltbox vs Cloudbox: reference/saltbox-vs-cloudbox.md
+          - Cloudplow Examples: reference/cloudplow.md
+          - Customizing Plex Libraries: reference/customizing-plex-libs.md
+          - Viewing Logs: reference/logs.md
+          - Multiple App Instances: reference/multiple-instances.md
+          - Shared-Drive Cloudplow Setup: reference/cloudplow-config.md
+          - Plex Auth Token: reference/plex_auth_token.md
+          - Ports: reference/ports.md
+          - Saltbox Tools: reference/saltbox-tools.md
+          - Adding a Subdomain: reference/subdomain.md
+          - Using Local Storage: reference/local-storage.md
+          - Mounting disks: reference/guides/mount.md
+          - HW transcoding on OVH: reference/ovh.md
+        - Deprecated Guides:
+          - Traefik 3.0 Upgrade: reference/guides/deprecated/traefik3.md


### PR DESCRIPTION
An attempt to dodge the below error during preview builds (since `enabled: !ENV [CI, false]` does not make mkdocs ignore a missing plugin).
```
Run mkdocs build --clean
ERROR   -  Config value 'plugins': The "optimize" plugin is not installed

Aborted with a configuration error!
Error: Process completed with exit code 1.
```