### PR TITLE
Fix installation command and update URL for Yourspotify

### DIFF
--- a/docs/sandbox/apps/yourspotify.md
+++ b/docs/sandbox/apps/yourspotify.md
@@ -28,12 +28,12 @@ Recommended install types: Saltbox, Core
 
 ``` shell
 
-sb install sandbox-your_spotify
+sb install sandbox-your-spotify
 
 ```
 
 ### 2. URL
 
-- To access Yourspotify, visit `https://your_spotify._yourdomain.com_`
+- To access Yourspotify, visit `https://spotify._yourdomain.com_`
 
 - [:octicons-link-16: Documentation: Yourspotify Docs](https://github.com/Yooooomi/your_spotify?tab=readme-ov-file#table-of-contents){: .header-icons }


### PR DESCRIPTION
Updated the install command to match the tag shown in `sb list`

For the subdomain, I checked the logs and saw it set the subdomain to something else:
<img width="414" height="30" alt="Untitled 2" src="https://github.com/user-attachments/assets/48094b25-5d16-4fa6-a318-1f1d3100536c" />


