### PR TITLE
Add Dispatcharr sandbox app docs

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -127,10 +127,11 @@ tags:
 
 ### IPTV Proxy
 
-|                                           | :material-monitor-arrow-down:{.xl} | :material-format-list-group-plus:{ .xl } |
-|-------------------------------------------|:----------------------------------:|:----------------------------------------:|
-| [Threadfin](../sandbox/apps/threadfin.md) |        `sandbox-threadfin`         |             `sandbox_roles`              |
-| [Xteve](../sandbox/apps/xteve.md)         |          `sandbox-xteve`           |             `sandbox_roles`              |
+|                                               | :material-monitor-arrow-down:{.xl} | :material-format-list-group-plus:{ .xl } |
+|-----------------------------------------------|:----------------------------------:|:----------------------------------------:|
+| [Dispatcharr](../sandbox/apps/dispatcharr.md) |       `sandbox-dispatcharr`        |             `sandbox_roles`              |
+| [Threadfin](../sandbox/apps/threadfin.md)     |        `sandbox-threadfin`         |             `sandbox_roles`              |
+| [Xteve](../sandbox/apps/xteve.md)             |          `sandbox-xteve`           |             `sandbox_roles`              |
 
 ### Reader
 

--- a/docs/sandbox/apps/dispatcharr.md
+++ b/docs/sandbox/apps/dispatcharr.md
@@ -24,7 +24,7 @@ saltbox_automation:
       an open-source IPTV and stream management application with EPG handling, M3U/Xtream Codes import, HDHomeRun emulation, and a stream proxy for Plex, Emby, and Jellyfin.
     link: https://github.com/Dispatcharr/Dispatcharr
     categories:
-      - Content Delivery Apps > Media Server Accessory > IPTV
+      - Content Delivery Apps > IPTV Proxy
 ---
 
 <!-- BEGIN SALTBOX MANAGED OVERVIEW SECTION -->

--- a/docs/sandbox/apps/dispatcharr.md
+++ b/docs/sandbox/apps/dispatcharr.md
@@ -1,0 +1,45 @@
+---
+icon: material/docker
+hide:
+  - tags
+tags:
+  - dispatcharr
+  - iptv
+  - streaming
+  - epg
+saltbox_automation:
+  app_links:
+    - name: Manual
+      url: https://dispatcharr.github.io/Dispatcharr-Docs/
+      type: documentation
+    - name: Releases
+      url: https://github.com/Dispatcharr/Dispatcharr/pkgs/container/dispatcharr
+      type: docker
+    - name: Community
+      url: https://discord.gg/Sp45V5BcxU
+      type: discord
+  project_description:
+    name: Dispatcharr
+    summary: |-
+      an open-source IPTV and stream management application with EPG handling, M3U/Xtream Codes import, HDHomeRun emulation, and a stream proxy for Plex, Emby, and Jellyfin.
+    link: https://github.com/Dispatcharr/Dispatcharr
+    categories:
+      - Content Delivery Apps > Media Server Accessory > IPTV
+---
+
+<!-- BEGIN SALTBOX MANAGED OVERVIEW SECTION -->
+# Dispatcharr
+<!-- END SALTBOX MANAGED OVERVIEW SECTION -->
+
+## Deployment
+
+```shell
+sb install sandbox-dispatcharr
+```
+
+## Usage
+
+Visit <https://dispatcharr.iYOUR_DOMAIN_NAMEi>.
+
+<!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
+<!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -316,6 +316,7 @@ nav:
           - sandbox/apps/deemix.md
           - sandbox/apps/delugevpn.md
           - sandbox/apps/discoflix.md
+          - sandbox/apps/dispatcharr.md
           - sandbox/apps/dockwatch.md
           - sandbox/apps/doplarr.md
           - sandbox/apps/duplicati.md


### PR DESCRIPTION
Adds the docs page for the new Dispatcharr sandbox role and registers it in the nav. Dispatcharr is an IPTV/stream management application with EPG handling, M3U/Xtream Codes import and an HDHomeRun tuner emulator for Plex/Emby/Jellyfin.

For new Sandbox app/role documentation, please confirm you have completed the following tasks:
- [x] App documentation page created with, at minimum:

  - [x] Front-matter fields filled: icon, saltbox_automation: app_links, project_description: name, summary, link, categories
  - [x] Managed overview and variables section delimiters
  - [x] `## Deployment` and `## Usage` sections

- [x] markdownlint reports no errors on edited page(s)
```
$ npx markdownlint-cli docs/sandbox/apps/dispatcharr.md
$
```
- [x] Reference added in `mkdocs.yml` nav menu

Related: Sandbox PR #[533](https://github.com/saltyorg/Sandbox/pull/533)