### PR TITLE
feat(os): add Ubuntu 26.04 LTS (Resolute Raccoon) support

### DIFF
--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -12,7 +12,7 @@ tags:
 
 About the requirements:
 
-You will need a dedicated server freshly installed with Ubuntu Server [22.04](https://releases.ubuntu.com/22.04/), or [24.04](https://releases.ubuntu.com/24.04/).
+You will need a dedicated server freshly installed with Ubuntu Server [24.04](https://releases.ubuntu.com/24.04/) or [26.04](https://releases.ubuntu.com/26.04/). Ubuntu [22.04](https://releases.ubuntu.com/22.04/) is still supported but no longer recommended for new installs.
 
 This server can be either local to you or rented from a server provider.
 
@@ -24,7 +24,7 @@ When you install Ubuntu on the server, do not preinstall anything other than Ope
 
 The install assumes that this is a fresh setup without anything else installed. If your server has things like Docker preinstalled, chances are the installer will fail with a non-obvious error, or other problems will show up later.
 
-In other words, you should not upgrade your Ubuntu 18.04 machine running Cloudbox to Ubuntu 22.04 and then install Saltbox on top of it. You should wipe the machine, install 22.04 or 24.04 fresh and start there.
+In other words, you should not upgrade your Ubuntu 18.04 machine running Cloudbox to Ubuntu 22.04 and then install Saltbox on top of it. You should wipe the machine, install 24.04 or 26.04 fresh and start there.
 
 Typically this server is remote to you; you can install on a home server, keeping in mind some [home server considerations](#home-server-considerations)
 

--- a/docs/saltbox/basics/basics.md
+++ b/docs/saltbox/basics/basics.md
@@ -13,7 +13,7 @@ tags:
 
 ## What is Saltbox?
 
-- [Saltbox](https://github.com/saltyorg/Saltbox) is an [Ansible](https://www.ansible.com/how-ansible-works) and [Docker](https://www.docker.com/what-container) based solution for rapidly deploying a media server using LTS releases of Ubuntu Server 22.04 or 24.04, running on AMD64. Non-LTS releases of Ubuntu or Desktop installations are not supported. Linux distributions other than Ubuntu are not supported. ARM processors, Raspberry Pi notably, are not supported.
+- [Saltbox](https://github.com/saltyorg/Saltbox) is an [Ansible](https://www.ansible.com/how-ansible-works) and [Docker](https://www.docker.com/what-container) based solution for rapidly deploying a media server using LTS releases of Ubuntu Server 22.04, 24.04, or 26.04, running on AMD64. Non-LTS releases of Ubuntu or Desktop installations are not supported. Linux distributions other than Ubuntu are not supported. ARM processors, Raspberry Pi notably, are not supported.
 
 - Primary functions are: the automatic acquisition of media, being able to play it back from anywhere and from any device, and, to a lesser extent, storing that media in a remote storage location.
 

--- a/docs/saltbox/prerequisites/prerequisites.md
+++ b/docs/saltbox/prerequisites/prerequisites.md
@@ -36,7 +36,7 @@ There are, broadly, 4 prerequisites to installing Saltbox:
 
 ### Operating Systems
 
-At this time, we only support LTS releases of Ubuntu Server [22.04](https://releases.ubuntu.com/22.04/), or [24.04](https://releases.ubuntu.com/24.04/), freshly installed.
+At this time, we only support LTS releases of Ubuntu Server [24.04](https://releases.ubuntu.com/24.04/), or [26.04](https://releases.ubuntu.com/26.04/), freshly installed.
 
 !!! warning
     Desktop editions are excluded. While Saltbox may technically run alongside a desktop environment, we will decline all forms of support around this use case.
@@ -47,7 +47,7 @@ For best results, the assumed server environment for Saltbox is:
 
 - a dedicated remote server (not a VPS or a virtualized setup like proxmox) (see below for important information about Hetzner),
 - with a processor compliant with the `x86_64`/`amd64` (`arm` NOT SUPPORTED) architecture,
-- running a brand new fresh install of the server version of Ubuntu 22.04, or 24.04,
+- running a brand new fresh install of the server version of Ubuntu 24.04 or 26.04,
 - from a server provider like Hetzner, OVH, kimsufi, etc.,
 - nothing else (docker, for example) preinstalled,
 - with at least 500GB of disk space, and


### PR DESCRIPTION
## Summary

Document Ubuntu 26.04 LTS support, and update the install guidance to
recommend the two latest LTS releases (24.04 or 26.04). Ubuntu 22.04 remains
supported but is no longer recommended for new installs.

## Changes

- **saltbox/basics/basics.md**: add 26.04 to the "What is Saltbox?"
  supported-OS sentence
- **saltbox/prerequisites/prerequisites.md**: list 22.04/24.04/26.04 as
  supported and recommend the two latest LTS (24.04 or 26.04); update the
  "assumed server environment" bullet to 24.04/26.04
- **reference/server.md**: recommend 24.04 or 26.04 for a fresh install
  (with a note that 22.04 is still supported); update the "wipe and install
  fresh" line

## Notes

- Support vs. recommendation are kept distinct: 22.04 stays in the support
  list; "what to install" guidance points at the two latest LTS.
- Incidental, non-recommendation mentions were intentionally left as-is

## Related

Adding Ubuntu 26.04 support will require merging changes across
**Saltbox**, **sb**, **sb-go**, and **docs**. Related PRs in these repos will be
submitted momentarily.

## Related PRs:

- **Saltbox:** https://github.com/saltyorg/Saltbox/pull/497
- **sb:** https://github.com/saltyorg/sb/pull/116
- **sb-go:** https://github.com/saltyorg/sb-go/pull/46
