### PR TITLE
docs-automation: blacklist sure_worker and autoplow from coverage

### DIFF
--- a/.docs-automation.yml
+++ b/.docs-automation.yml
@@ -32,6 +32,7 @@ blacklist:
   docs_coverage:
     saltbox:
       - "authentik_worker"
+      - "autoplow"  # alpha (0.0.x), gated behind acceptance prompt, no upstream description yet
       - "cloudflare"
       - "cloudplow_disable"
       - "hetzner"
@@ -46,6 +47,7 @@ blacklist:
     sandbox:
       - "homarr_legacy"
       - "sanity_check"
+      - "sure_worker"  # non-user-facing worker for the sure role
       # Deprecated roles
       - "booklore"  # deprecated
       - "unifi"  # deprecated


### PR DESCRIPTION
## Why

Issue #394 flags two roles with no documentation pages: `sure_worker` and `autoplow`. Both are better excluded from the coverage check than documented, for different reasons.

## sure_worker

`sandbox/sure_worker` is a non-user-facing backend worker for the `sure` role. It has no web exposure (no `_web_*` or `_traefik_*` config) and inherits its image from `sure`. This matches `authentik_worker`, which is already blacklisted under saltbox. Added to `blacklist.docs_coverage.sandbox`.

## autoplow

`autoplow` is alpha software (currently 0.0.41) and its Saltbox role gates installation behind an explicit alpha-acceptance prompt. The upstream repo has no description, README, or homepage, so there is no published material to document the tool from. Rather than ship a placeholder page with a TODO summary, this excludes it from coverage for now. Added to `blacklist.docs_coverage.saltbox`.

Happy to document `autoplow` instead if you would prefer, or once it has a public description and a stable release. Just say the word and I will switch this to a proper page.

## Effect

Both roles drop out of the `sb-docs --check` coverage scan, clearing the items in #394 without authoring empty pages.

Closes #394
