### PR TITLE
Add Silo sandbox app docs

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -18,11 +18,12 @@ tags:
 
 ### Media Server
 
-|                              |   :material-monitor-arrow-down:{ .xl }    | :material-format-list-group-plus:{ .xl } |
-|------------------------------|:-----------------------------------------:|:----------------------------------------:|
-| [Plex Media Server](plex.md) | `plex` `plex-reset-codecs` `plex-reclaim` |         `media_servers_enabled`          |
-| [Emby](emby.md)              |                  `emby`                   |         `media_servers_enabled`          |
-| [Jellyfin](jellyfin.md)      |                `jellyfin`                 |         `media_servers_enabled`          |
+|                                 |   :material-monitor-arrow-down:{ .xl }    | :material-format-list-group-plus:{ .xl } |
+|---------------------------------|:------------------------------------------:|:----------------------------------------:|
+| [Plex Media Server](plex.md)    | `plex` `plex-reset-codecs` `plex-reclaim`  |         `media_servers_enabled`          |
+| [Emby](emby.md)                 |                   `emby`                   |         `media_servers_enabled`          |
+| [Jellyfin](jellyfin.md)         |                 `jellyfin`                 |         `media_servers_enabled`          |
+| [Silo](../sandbox/apps/silo.md) |               `sandbox-silo`               |             `sandbox_roles`              |
 
 ### Audio Server
 

--- a/docs/sandbox/apps/silo.md
+++ b/docs/sandbox/apps/silo.md
@@ -1,0 +1,59 @@
+---
+icon: material/docker
+hide:
+  - tags
+tags:
+  - silo
+  - media
+  - streaming
+  - transcoding
+saltbox_automation:
+  app_links:
+    - name: Manual
+      url: https://github.com/Silo-Server/silo-server/tree/main/docs
+      type: documentation
+    - name: Releases
+      url: https://github.com/Silo-Server/silo-server/pkgs/container/silo-server
+      type: docker
+    - name: Community
+      url: https://discord.gg/4RxuUQAEnW
+      type: community
+  project_description:
+    name: Silo
+    summary: |-
+      a self-hosted media server for movies, shows, music, and books with direct play, transcoding, and optional Jellyfin-compatible client support.
+    link: https://github.com/Silo-Server/silo-server
+    categories:
+      - Content Delivery Apps > Media Server
+---
+
+<!-- BEGIN SALTBOX MANAGED OVERVIEW SECTION -->
+# Silo
+<!-- END SALTBOX MANAGED OVERVIEW SECTION -->
+
+## Deployment
+
+```shell
+sb install sandbox-silo
+```
+
+The role also deploys PostgreSQL with pgvector and Redis.
+
+## Usage
+
+Visit <https://silo.iYOUR_DOMAIN_NAMEi>.
+
+Configure libraries against the usual `/mnt/unionfs/...` paths in the admin UI.
+
+Transient transcodes use the configured Saltbox transcodes path and are
+mounted at `/tmp/silo-transcode`. Hardware transcoding uses Saltbox's standard
+Intel or NVIDIA device configuration.
+
+## Compatible Clients
+
+Silo's Jellyfin-compatible API is disabled by default and listens on a
+separate port when enabled. The Sandbox role currently exposes only Silo's
+main web service through Traefik.
+
+<!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
+<!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/docs/sandbox/apps/silo.md
+++ b/docs/sandbox/apps/silo.md
@@ -10,25 +10,24 @@ tags:
 saltbox_automation:
   app_links:
     - name: Manual
-      url: https://github.com/Silo-Server/silo-server/tree/main/docs
+      url: https://siloserver.org/docs
       type: documentation
     - name: Releases
       url: https://github.com/Silo-Server/silo-server/pkgs/container/silo-server
-      type: docker
+      type: github
     - name: Community
       url: https://discord.gg/4RxuUQAEnW
-      type: community
+      type: discord
   project_description:
     name: Silo
     summary: |-
       a self-hosted media server for movies, shows, music, and books with direct play, transcoding, and optional Jellyfin-compatible client support.
-    link: https://github.com/Silo-Server/silo-server
+    link: https://siloserver.org
     categories:
       - Content Delivery Apps > Media Server
 ---
 
 <!-- BEGIN SALTBOX MANAGED OVERVIEW SECTION -->
-# Silo
 <!-- END SALTBOX MANAGED OVERVIEW SECTION -->
 
 ## Deployment
@@ -37,27 +36,11 @@ saltbox_automation:
 sb install sandbox-silo
 ```
 
-The role also deploys PostgreSQL with pgvector and Redis.
-
-Silo runs as the Saltbox UID:GID rather than the image's root default. The
-role sets `HOME` to `/tmp` and adds the video and render GIDs for hardware
-access.
-
 ## Usage
 
 Visit <https://silo.iYOUR_DOMAIN_NAMEi>.
 
 Configure libraries against the usual `/mnt/unionfs/...` paths in the admin UI.
-
-Transient transcodes use the configured Saltbox transcodes path and are
-mounted at `/tmp/silo-transcode`. Hardware transcoding uses Saltbox's standard
-Intel or NVIDIA device configuration.
-
-## Compatible Clients
-
-Silo's Jellyfin-compatible API is disabled by default and listens on a
-separate port when enabled. The Sandbox role currently exposes only Silo's
-main web service through Traefik.
 
 <!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
 <!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/docs/sandbox/apps/silo.md
+++ b/docs/sandbox/apps/silo.md
@@ -39,6 +39,10 @@ sb install sandbox-silo
 
 The role also deploys PostgreSQL with pgvector and Redis.
 
+Silo runs as the Saltbox UID:GID rather than the image's root default. The
+role sets `HOME` to `/tmp` and adds the video and render GIDs for hardware
+access.
+
 ## Usage
 
 Visit <https://silo.iYOUR_DOMAIN_NAMEi>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -418,6 +418,7 @@ nav:
           - sandbox/apps/sabthrottle.md
           - sandbox/apps/semaphoreui.md
           - sandbox/apps/shelfmark.md
+          - sandbox/apps/silo.md
           - sandbox/apps/slskd.md
           - sandbox/apps/speedtest.md
           - sandbox/apps/sqlitebrowser.md


### PR DESCRIPTION
## Summary

Adds the companion documentation for the Silo Sandbox role in saltyorg/Sandbox#538.

- Adds the Silo app page with deployment and usage guidance.
- Adds Silo to the media-server index and Sandbox navigation.
- Documents the non-root runtime, standard media and transcode paths, hardware acceleration behavior, and the current scope of the optional Jellyfin-compatible listener.
- Updates the community link to Silo's official Discord.

The deployment guidance was checked against the current Silo README, Compose file, environment example, and repository documentation.

## Testing

- `markdownlint-cli2 docs/sandbox/apps/silo.md`: 0 issues
- `mkdocs build --clean`: passed against current `saltyorg/docs` main
- `git diff --check`: passed

This PR can merge after the Sandbox role PR.
