### PR TITLE
Add tofa docs

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -24,6 +24,7 @@ tags:
 | [Emby](emby.md)                 |                  `emby`                   |         `media_servers_enabled`          |
 | [Jellyfin](jellyfin.md)         |                `jellyfin`                 |         `media_servers_enabled`          |
 | [Silo](../sandbox/apps/silo.md) |              `sandbox-silo`               |             `sandbox_roles`              |
+| [tofa](../sandbox/apps/tofa.md) |              `sandbox-tofa`               |             `sandbox_roles`              |
 
 ### Audio Server
 

--- a/docs/sandbox/apps/tofa.md
+++ b/docs/sandbox/apps/tofa.md
@@ -13,7 +13,7 @@ saltbox_automation:
       url: https://docs.tofa.tv
       type: documentation
     - name: Releases
-      url: https://docs.tofa.tv/whats-new.html
+      url: https://github.com/orgs/tofatv/packages/container/package/tofa
       type: releases
     - name: Community
       url: https://tofa.tv/discord
@@ -40,18 +40,13 @@ sb install sandbox-tofa
 
 Visit <https://tofa.iYOUR_DOMAIN_NAMEi>.
 
-### First-run setup
-
-The server is claimed once, on first run, which links it to your tofa
-account. Because the Saltbox install is reached through a public domain,
-that first claim has to carry the setup token the server generates on boot:
+The server is claimed once, on first run, which links it to your tofa account. Because the Saltbox install is reached through a public domain, that first claim has to carry the setup token the server generates on boot:
 
 ```shell
 sudo cat /opt/tofa/identity/setup_key.secret
 ```
 
-Then open `https://tofa.iYOUR_DOMAIN_NAMEi/setup?setup_token=<token>` and
-follow the wizard. The token is only consulted while the server is unclaimed.
+Then open `https://tofa.iYOUR_DOMAIN_NAMEi/setup?setup_token=<token>` and follow the wizard. The token is only consulted while the server is unclaimed.
 
 Add libraries from the usual `/mnt/unionfs/Media` paths in `Admin > Libraries`.
 

--- a/docs/sandbox/apps/tofa.md
+++ b/docs/sandbox/apps/tofa.md
@@ -42,7 +42,7 @@ Visit <https://tofa.iYOUR_DOMAIN_NAMEi>.
 
 ### First-run setup
 
-The server is claimed once, on first run. Because the Saltbox install is reached through a public domain, that first claim has to carry the setup token that the container generates on boot:
+The server is claimed once, on first run, which links it to your tofa account. Because the Saltbox install is reached through a public domain, that first claim has to carry the setup token the server generates on boot:
 
 ```shell
 sudo cat /opt/tofa/identity/setup_key.secret
@@ -60,18 +60,9 @@ Transcode segments are written to `transcodes_path`, not to the appdata disk.
 
 ### Remote access
 
-Clients reach the server over the Traefik URL, which the role advertises to them automatically. No ports are published on the host by default.
+Clients reach the server over the Traefik URL, which the role advertises to them automatically. No ports are published on the host.
 
-!!! info "Direct LAN connections"
-
-    To let clients on your own network connect straight to the server instead of going out and back through your domain, publish the port and advertise the LAN address:
-
-    ```yaml
-    tofa_role_open_main_ports: true
-    tofa_role_lan_ip: "192.168.1.100"
-    ```
-
-    The port is only published when `tofa_role_open_main_ports` is enabled, so `tofa_role_lan_ip` has no effect on its own.
+On a home server, clients on your own network can be given a direct LAN address instead, so their traffic does not leave and re-enter through your domain. That needs both `tofa_role_open_main_ports` and `tofa_role_lan_ip` below.
 
 <!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
 <!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/docs/sandbox/apps/tofa.md
+++ b/docs/sandbox/apps/tofa.md
@@ -55,24 +55,5 @@ follow the wizard. The token is only consulted while the server is unclaimed.
 
 Add libraries from the usual `/mnt/unionfs/Media` paths in `Admin > Libraries`.
 
-### Hardware transcoding
-
-The role enables GPU access, so the container picks up `/dev/dri` when
-`gpu.intel` is set, and the NVIDIA runtime when `nvidia_enabled` is set. The
-setup wizard detects what is available and the choice can be changed later in
-`Admin > Settings > Transcoding`.
-
-Transcode segments are written to `transcodes_path`, not to the appdata disk.
-
-### Remote access
-
-Clients reach the server over the Traefik URL, which the role advertises to
-them automatically. No ports are published on the host.
-
-On a home server, clients on your own network can be given a direct LAN
-address instead, so their traffic does not leave and re-enter through your
-domain. That needs both `tofa_role_open_main_ports` and `tofa_role_lan_ip`
-below.
-
 <!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
 <!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/docs/sandbox/apps/tofa.md
+++ b/docs/sandbox/apps/tofa.md
@@ -1,0 +1,77 @@
+---
+icon: material/docker
+hide:
+  - tags
+tags:
+  - tofa
+  - media
+  - streaming
+  - transcoding
+saltbox_automation:
+  app_links:
+    - name: Manual
+      url: https://docs.tofa.tv
+      type: documentation
+    - name: Releases
+      url: https://docs.tofa.tv/whats-new.html
+      type: releases
+    - name: Community
+      url: https://tofa.tv/discord
+      type: discord
+  project_description:
+    name: tofa
+    summary: |-
+      a self-hosted media server for streaming your own movie and TV library to web, mobile, and TV apps, with hardware-accelerated transcoding.
+    link: https://tofa.tv
+    categories:
+      - Content Delivery Apps > Media Server
+---
+
+<!-- BEGIN SALTBOX MANAGED OVERVIEW SECTION -->
+<!-- END SALTBOX MANAGED OVERVIEW SECTION -->
+
+## Deployment
+
+```shell
+sb install sandbox-tofa
+```
+
+## Usage
+
+Visit <https://tofa.iYOUR_DOMAIN_NAMEi>.
+
+### First-run setup
+
+The server is claimed once, on first run. Because the Saltbox install is reached through a public domain, that first claim has to carry the setup token that the container generates on boot:
+
+```shell
+sudo cat /opt/tofa/identity/setup_key.secret
+```
+
+Then open `https://tofa.iYOUR_DOMAIN_NAMEi/setup?setup_token=<token>` and follow the wizard. The token is only consulted while the server is unclaimed.
+
+Add libraries from the usual `/mnt/unionfs/Media` paths in `Admin > Libraries`.
+
+### Hardware transcoding
+
+The role enables GPU access, so the container picks up `/dev/dri` when `gpu.intel` is set, and the NVIDIA runtime when `nvidia_enabled` is set. The setup wizard detects what is available and the choice can be changed later in `Admin > Settings > Transcoding`.
+
+Transcode segments are written to `transcodes_path`, not to the appdata disk.
+
+### Remote access
+
+Clients reach the server over the Traefik URL, which the role advertises to them automatically. No ports are published on the host by default.
+
+!!! info "Direct LAN connections"
+
+    To let clients on your own network connect straight to the server instead of going out and back through your domain, publish the port and advertise the LAN address:
+
+    ```yaml
+    tofa_role_open_main_ports: true
+    tofa_role_lan_ip: "192.168.1.100"
+    ```
+
+    The port is only published when `tofa_role_open_main_ports` is enabled, so `tofa_role_lan_ip` has no effect on its own.
+
+<!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
+<!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/docs/sandbox/apps/tofa.md
+++ b/docs/sandbox/apps/tofa.md
@@ -42,27 +42,37 @@ Visit <https://tofa.iYOUR_DOMAIN_NAMEi>.
 
 ### First-run setup
 
-The server is claimed once, on first run, which links it to your tofa account. Because the Saltbox install is reached through a public domain, that first claim has to carry the setup token the server generates on boot:
+The server is claimed once, on first run, which links it to your tofa
+account. Because the Saltbox install is reached through a public domain,
+that first claim has to carry the setup token the server generates on boot:
 
 ```shell
 sudo cat /opt/tofa/identity/setup_key.secret
 ```
 
-Then open `https://tofa.iYOUR_DOMAIN_NAMEi/setup?setup_token=<token>` and follow the wizard. The token is only consulted while the server is unclaimed.
+Then open `https://tofa.iYOUR_DOMAIN_NAMEi/setup?setup_token=<token>` and
+follow the wizard. The token is only consulted while the server is unclaimed.
 
 Add libraries from the usual `/mnt/unionfs/Media` paths in `Admin > Libraries`.
 
 ### Hardware transcoding
 
-The role enables GPU access, so the container picks up `/dev/dri` when `gpu.intel` is set, and the NVIDIA runtime when `nvidia_enabled` is set. The setup wizard detects what is available and the choice can be changed later in `Admin > Settings > Transcoding`.
+The role enables GPU access, so the container picks up `/dev/dri` when
+`gpu.intel` is set, and the NVIDIA runtime when `nvidia_enabled` is set. The
+setup wizard detects what is available and the choice can be changed later in
+`Admin > Settings > Transcoding`.
 
 Transcode segments are written to `transcodes_path`, not to the appdata disk.
 
 ### Remote access
 
-Clients reach the server over the Traefik URL, which the role advertises to them automatically. No ports are published on the host.
+Clients reach the server over the Traefik URL, which the role advertises to
+them automatically. No ports are published on the host.
 
-On a home server, clients on your own network can be given a direct LAN address instead, so their traffic does not leave and re-enter through your domain. That needs both `tofa_role_open_main_ports` and `tofa_role_lan_ip` below.
+On a home server, clients on your own network can be given a direct LAN
+address instead, so their traffic does not leave and re-enter through your
+domain. That needs both `tofa_role_open_main_ports` and `tofa_role_lan_ip`
+below.
 
 <!-- BEGIN SALTBOX MANAGED VARIABLES SECTION -->
 <!-- END SALTBOX MANAGED VARIABLES SECTION -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -434,6 +434,7 @@ nav:
           - sandbox/apps/thelounge.md
           - sandbox/apps/threadfin.md
           - sandbox/apps/tika.md
+          - sandbox/apps/tofa.md
           - sandbox/apps/tqm.md
           - sandbox/apps/traccar.md
           - sandbox/apps/traefik_robotstxt.md


### PR DESCRIPTION
Adds the companion documentation for the tofa Sandbox role in saltyorg/Sandbox#556.

- Adds the tofa app page with deployment, first-run claim, hardware transcoding, and remote access guidance.
- Adds tofa to the media-server index and Sandbox navigation.
- Documents the setup token needed to claim the server through a public domain, the standard media and transcode paths, and hardware acceleration behavior.

The guidance was checked against the role defaults in the Sandbox PR and against the server's own setup gate. 
