### PR TITLE
fix(ci): remove untrusted PR artifact metadata

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,5 +1,5 @@
 name: Build PR & Deploy
-run-name: PR #${{ github.event.workflow_run.pull_requests[0].number }} - ${{ github.event.workflow_run.display_title }}
+run-name: "PR #${{ github.event.workflow_run.pull_requests[0].number }} - ${{ github.event.workflow_run.display_title }}"
 
 on:
   workflow_run:

--- a/.github/workflows/trigger-pr-build.yml
+++ b/.github/workflows/trigger-pr-build.yml
@@ -57,15 +57,9 @@ jobs:
           path: .cache
           key: docs-${{ github.event.pull_request.number }}-${{ github.run_id }}
 
-      - name: Prepare Artifact Bundle
-        run: |
-          mkdir -p ./pr_bundle
-          echo ${{ github.event.pull_request.number }} > ./pr_bundle/PR_NUMBER
-          echo ${{ github.event.pull_request.head.sha }} > ./pr_bundle/PR_SHA
-          mv site ./pr_bundle/site
-
-      - name: Upload Build Artifacts
+      - name: Upload built site
         uses: actions/upload-artifact@v7
         with:
           name: pr_build_artifacts
-          path: pr_bundle/
+          path: site/
+          retention-days: 1


### PR DESCRIPTION
## Summary

- upload only the generated site from pull-request builds
- stop carrying PR number and commit SHA in the untrusted artifact
- rely on the trusted workflow_run context deployed in #416
- retain one-day artifact storage

## Validation

- 11 PR preview regression tests pass, including both legacy and site-only artifact layouts
- targeted actionlint 1.7.12 passes
- git diff --check passes
